### PR TITLE
listeners of type "after" do not fire if a route hook is set on the same URL in some cases

### DIFF
--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -859,7 +859,7 @@ public class HookHandler implements LoggableResource {
 
                     if (doMethodsMatch(route, request) && doHeadersMatch(route, request)) {
                         log.debug("Forward request (consumed) {}", request.uri());
-                        route.forward(request, buffer);
+                        route.forward(request, buffer, afterHandler);
                     } else {
                         // mark the original request as hooked
                         request.headers().set(HOOKED_HEADER, "true");

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
@@ -1,5 +1,7 @@
 package org.swisspush.gateleen.hook;
 
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
@@ -222,15 +224,15 @@ public class Route {
      * @param request - the original but already consumed request
      * @param requestBody - saved buffer with the data of body from the original request
      */
-    public void forward(HttpServerRequest request, final Buffer requestBody) {
+    public void forward(HttpServerRequest request, final Buffer requestBody, @Nullable final Handler<Void> afterHandler) {
 
         // checking if the forwarder is for all methods
         if (httpHook.getMethods().isEmpty()) {
-            forwarder.handle(request, requestBody);
+            forwarder.handle(request, requestBody, afterHandler);
         } else {
             // checking if the method from the request is handled by this forwarder
             if (httpHook.getMethods().contains(request.method().name())) {
-                forwarder.handle(request, requestBody);
+                forwarder.handle(request, requestBody, afterHandler);
             }
         }
     }
@@ -242,7 +244,7 @@ public class Route {
      * @param request request
      */
     public void forward(HttpServerRequest request) {
-        forward(request, null);
+        forward(request, null, null);
     }
 
     /**

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
@@ -2,6 +2,7 @@ package org.swisspush.gateleen.hook;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.common.collect.ImmutableMap;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
 import io.restassured.RestAssured;
@@ -499,6 +500,75 @@ public class ListenerTest extends AbstractTest {
         checkGETStatusCodeWithAwait(targetUrlListener1, 404);
 
         TestUtils.unregisterListener(registerUrlListener1);
+
+        async.complete();
+    }
+
+    @Test
+    public void testAfterTriggerTypeWithRoute(TestContext context) {
+        Async async = context.async();
+        delete();
+        JsonObject rules = new JsonObject();
+
+        // Settings
+        String subresource = "afterListener";
+        String listenerName = "listenerName";
+        String routeName = "routePathTest";
+        String resourceBase = requestUrlBase + "/" + subresource;
+
+        String registerUrlListener = resourceBase + TestUtils.getHookListenersUrlSuffix() + listenerName;
+        String targetListener = targetUrlBase + "/" + listenerName;
+        String[] methods = new String[]{"GET", "PUT", "DELETE", "POST"};
+        final String hookAfterTarget = targetListener + "/" + "test";
+
+        // -------
+        final String requestUrl = resourceBase + TestUtils.getHookRouteUrlSuffix();
+        final String body = "{ \"name\" : \"" + subresource + "\"}";
+        final String target = SERVER_ROOT + "/tests/gateleen/targetresource/" + routeName;
+
+        final String routedResource = resourceBase + "/test";
+        final String routeTarget = targetUrlBase + "/" + routeName + "/test";
+
+        JsonObject rule = TestUtils.createRoutingRule(ImmutableMap.of(
+                "description",
+                "Respond the request with status code 503",
+                "path",
+                SERVER_ROOT + "/return-with-status-code/503"));
+
+        rules = TestUtils.addRoutingRuleMainStorage(rules);
+        rules = TestUtils.addRoutingRule(rules, SERVER_ROOT + routedResource, rule);
+        rules = TestUtils.addRoutingRuleHooks(rules);
+
+        TestUtils.putRoutingRules(rules);
+
+        delete(requestUrl);
+        delete(hookAfterTarget);
+        delete(routeTarget);
+
+        /*
+         * Sending request, listener hooked
+         */
+        TestUtils.registerListener(registerUrlListener, targetListener, methods, null, null, null, HookTriggerType.AFTER, null);
+
+        checkPUTStatusCode(routedResource, body, 503);
+        checkGETStatusCodeWithAwait(routedResource, 503);
+        checkGETStatusCodeWithAwait(routeTarget, 404);
+        checkGETStatusCodeWithAwait(hookAfterTarget, 404);
+
+        // add a routing
+        TestUtils.registerRoute(requestUrl, target, methods);
+
+        checkPUTStatusCode(routedResource, body, 200);
+        checkGETStatusCodeWithAwait(routedResource, 200);
+        checkGETBodyWithAwait(routeTarget, body);
+        checkGETBodyWithAwait(hookAfterTarget, body);
+
+        checkDELETEStatusCode(routedResource, 200);
+        checkGETStatusCodeWithAwait(routedResource, 404);
+        checkGETStatusCodeWithAwait(routeTarget, 404);
+        checkGETStatusCodeWithAwait(hookAfterTarget, 404);
+
+        TestUtils.unregisterListener(registerUrlListener);
 
         async.complete();
     }


### PR DESCRIPTION
This is relevant for a case where we have a listener hook of type "after"

  PUT http://localhost:7013/**somehost/data/mytest**/_hooks/**listeners**/http/somehost/just-a-test
  {
    "methods": [
      "POST", 
      "PUT", 
      "DELETE"
    ],
    "destination": "/somehost/data/another-target", 
    "type": "**after**"
  }

and on the very same endpoint also a route hook

PUT http://localhost:7013/**somehost/data/mytest**/_hooks/**route**
  {
    "methods": [
      "POST", 
      "PUT", 
      "DELETE"
    ],
    "destination": "/somehost/data/mytestroutetarget"
  }  

and there is also a static route like this

  "/**somehost/data/mytest**/(.*)": {
    "path": "/somehost/server/return-http-error/503"
  },

With this PR the listener hook will be called in case that the request can be successfully forward with the route hook, before it wasn't called.
