### PR TITLE
changed the poolsize evaluation if running in a cluster, simply round up

### DIFF
--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -36,6 +36,7 @@ import org.swisspush.gateleen.queue.queuing.QueueProcessor;
 import org.swisspush.gateleen.queue.queuing.RequestQueue;
 import org.swisspush.gateleen.routing.Router;
 import org.swisspush.gateleen.routing.Rule;
+import org.swisspush.gateleen.routing.RuleFactory;
 import org.swisspush.gateleen.validation.RegexpValidator;
 import org.swisspush.gateleen.validation.ValidationException;
 
@@ -1536,14 +1537,10 @@ public class HookHandler implements LoggableResource {
         Integer originalPoolSize = jsonHook.getInteger(HttpHook.CONNECTION_POOL_SIZE_PROPERTY_NAME);
         int appliedPoolSize;
         if (originalPoolSize != null) {
-            appliedPoolSize = Math.floorDiv(originalPoolSize, routeMultiplier);
-            if (appliedPoolSize < 1) {
-                appliedPoolSize = originalPoolSize;
-            }
+            appliedPoolSize = RuleFactory.evaluatePoolSize(originalPoolSize, routeMultiplier);
             log.debug("Original pool size is {}, applied size is {}", originalPoolSize, appliedPoolSize);
             hook.setConnectionPoolSize(appliedPoolSize);
         }
-
 
         hook.setMaxWaitQueueSize(jsonHook.getInteger(HttpHook.CONNECTION_MAX_WAIT_QUEUE_SIZE_PROPERTY_NAME));
         // Configure request timeout

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RuleFactory.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RuleFactory.java
@@ -91,10 +91,8 @@ public class RuleFactory {
             ruleObj.setPoolSize(rule.getInteger(Rule.CONNECTION_POOL_SIZE_PROPERTY_NAME, Rule.CONNECTION_POOL_SIZE_DEFAULT_VALUE));
 
             int originalPoolSize = ruleObj.getPoolSize();
-            int appliedPoolSize = Math.floorDiv(originalPoolSize, routeMultiplier);
-            if (appliedPoolSize < 1) {
-                appliedPoolSize = originalPoolSize;
-            }
+            int appliedPoolSize = evaluatePoolSize(originalPoolSize, routeMultiplier);
+
             ruleObj.setPoolSize(appliedPoolSize);
             log.debug("Original pool size is {}, applied size is {}", originalPoolSize, appliedPoolSize);
 
@@ -134,6 +132,14 @@ public class RuleFactory {
             result.add(ruleObj);
         }
         return result;
+    }
+
+    public static int evaluatePoolSize(int originalPoolSize, int routeMultiplier) {
+        return ceilDiv(originalPoolSize, routeMultiplier);
+    }
+
+    private static int ceilDiv(int x, int y){
+        return -Math.floorDiv(-x,y);
     }
 
     private void setStorage(Rule ruleObj, JsonObject rule, String path) throws ValidationException {

--- a/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/RuleFactoryTest.java
+++ b/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/RuleFactoryTest.java
@@ -720,7 +720,7 @@ public class RuleFactoryTest {
         rules = new RuleFactory(properties, routingRulesSchema).parseRules(Buffer.buffer(rule), 3);
 
         context.assertTrue(rules.size() == 1);
-        context.assertEquals(3, rules.get(0).getPoolSize());
+        context.assertEquals(4, rules.get(0).getPoolSize());
     }
 
     @Test

--- a/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/RuleFactoryTest.java
+++ b/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/RuleFactoryTest.java
@@ -4,6 +4,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.ProxyType;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -720,5 +721,13 @@ public class RuleFactoryTest {
 
         context.assertTrue(rules.size() == 1);
         context.assertEquals(3, rules.get(0).getPoolSize());
+    }
+
+    @Test
+    public void testPoolSizeEvaluation() {
+        Assert.assertEquals(20, RuleFactory.evaluatePoolSize(100, 5));
+        Assert.assertEquals(17, RuleFactory.evaluatePoolSize(33, 2));
+        Assert.assertEquals(1, RuleFactory.evaluatePoolSize(5, 5));
+        Assert.assertEquals(1, RuleFactory.evaluatePoolSize(4, 5));
     }
 }


### PR DESCRIPTION
The behavior change is here:

NOW:
Assert.assertEquals(1, RuleFactory.evaluatePoolSize(4, 5)); // configured 4, 5 cluster nodes
-> results in a total of 5 connection, close to what is configured

BEFORE:
Assert.assertEquals(4, RuleFactory.evaluatePoolSize(4, 5)); // configured 4, 5 cluster nodes
-> results in a total of 20 connection, higher than configured


The idea is to protect the third party / external system when running in a cluster configuration. In cases where small connection pool sizes are configured (smaller than the number of cluster nodes) we used the originalPoolSize. This resulted in a pool size of n x originalPoolSize which is possibly more then the external system can handle / against the idea of protection. With this PR we now end up with a connection pool size of 1 (per node) in such situations.

