### PR TITLE
Changed log message from error to info

### DIFF
--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
@@ -413,7 +413,7 @@ public class Forwarder extends AbstractForwarder {
                 }
                 error(exception.getMessage(), req, targetUri);
                 if (req.response().ended() || req.response().headWritten()) {
-                    error("Response already written. Not sure about the state. Closing server connection for stability reason", req, targetUri);
+                    LOG.info("{}: Response already written. Not sure about the state. Closing server connection for stability reason", targetUri);
                     req.response().close();
                     return;
                 }


### PR DESCRIPTION
Reason: Writing an error message here is confusing. Error messages imply that an exception has happened so some action is required to fix it. However during request forwarding here the exception is only a subsequent error of something that happened on either side (consumer / receiver) of the forwarding process (maybe the consumer cancelled because of a timeout or the receiver run into an exception during transmission of a large response). Whatever happened ought to be logged already in the log of the consumer and/or receiver and THAT is the message(s) that requires attention and action. The error message here is just generating a lot of noise without pointing into the direction of the real problem.