### PR TITLE
Do logfor non-number redis metrics

### DIFF
--- a/gateleen-monitoring/src/main/java/org/swisspush/gateleen/monitoring/RedisMonitor.java
+++ b/gateleen-monitoring/src/main/java/org/swisspush/gateleen/monitoring/RedisMonitor.java
@@ -135,7 +135,9 @@ public class RedisMonitor {
                     publisher.publishMetric(key, value);
                 }
             } catch (NumberFormatException e) {
-                // ignore this field
+                if(log.isTraceEnabled()) {
+                    log.trace("ignore field '{}' because '{}' doesnt look number-ish enough", key, valueStr);
+                }
             }
         });
     }

--- a/gateleen-monitoring/src/main/java/org/swisspush/gateleen/monitoring/RedisMonitor.java
+++ b/gateleen-monitoring/src/main/java/org/swisspush/gateleen/monitoring/RedisMonitor.java
@@ -135,9 +135,7 @@ public class RedisMonitor {
                     publisher.publishMetric(key, value);
                 }
             } catch (NumberFormatException e) {
-                if(log.isTraceEnabled()) {
-                    log.trace("ignore field '{}' because '{}' doesnt look number-ish enough", key, valueStr);
-                }
+                log.trace("ignore field '{}' because '{}' doesnt look number-ish enough", key, valueStr);
             }
         });
     }


### PR DESCRIPTION
Since there are many entries when calling redis INFO which are not numbers only, we want to be able to log them