### PR TITLE
Reduce logging of some stacks

### DIFF
--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/AbstractForwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/AbstractForwarder.java
@@ -4,7 +4,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.swisspush.gateleen.core.http.RequestLoggerFactory;
 import org.swisspush.gateleen.core.util.HttpHeaderUtil;
 import org.swisspush.gateleen.core.util.ResponseStatusCodeLogUtil;
@@ -13,11 +12,8 @@ import org.swisspush.gateleen.logging.LogAppenderRepository;
 import org.swisspush.gateleen.logging.LoggingResourceManager;
 import org.swisspush.gateleen.monitoring.MonitoringHandler;
 
-import static org.slf4j.LoggerFactory.getLogger;
-
 public abstract class AbstractForwarder implements Handler<RoutingContext> {
 
-    private static final Logger log = getLogger(AbstractForwarder.class);
     protected final Rule rule;
     protected final LoggingResourceManager loggingResourceManager;
     protected final LogAppenderRepository logAppenderRepository;


### PR DESCRIPTION
This case often happens in scenarios with timeouts. Which usually will end up so that the HTTP response is already sent. Then when the result finally arrives, gateleen tries to respond again. Which then leads to stacktraces being logged, where we usually do not want them. I think a warning log should suffice in this case.