### PR TITLE
Errors should be reported ONCE

### DIFF
--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/exception/GateleenExceptionFactory.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/exception/GateleenExceptionFactory.java
@@ -36,6 +36,14 @@ public interface GateleenExceptionFactory {
 
     public Exception newException(String msg, Throwable cause);
 
+    /** Convenience overload for {@link #newIllegalStateException(String, Throwable)}. */
+    public default IllegalStateException newIllegalStateException(String msg) { return newIllegalStateException(msg, null); }
+
+    /** Convenience overload for {@link #newIllegalStateException(String, Throwable)}. */
+    public default IllegalStateException newIllegalStateException(Throwable cause) { return newIllegalStateException(null, cause); }
+
+    public IllegalStateException newIllegalStateException(String msg, Throwable cause);
+
     public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String message);
 
 

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/exception/GateleenThriftyExceptionFactory.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/exception/GateleenThriftyExceptionFactory.java
@@ -17,6 +17,12 @@ class GateleenThriftyExceptionFactory implements GateleenExceptionFactory {
     }
 
     @Override
+    public IllegalStateException newIllegalStateException(String msg, Throwable cause) {
+        if (cause instanceof IllegalStateException) return (IllegalStateException) cause;
+        return new NoStackIllegalStateException(msg);
+    }
+
+    @Override
     public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String message) {
         return new GateleenNoStackReplyException(failureType, failureCode, message);
     }

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/exception/GateleenWastefulExceptionFactory.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/exception/GateleenWastefulExceptionFactory.java
@@ -16,6 +16,11 @@ class GateleenWastefulExceptionFactory implements GateleenExceptionFactory {
     }
 
     @Override
+    public IllegalStateException newIllegalStateException(String msg, Throwable cause) {
+        return new IllegalStateException(msg, cause);
+    }
+
+    @Override
     public ReplyException newReplyException(ReplyFailure failureType, int failureCode, String message) {
         return new ReplyException(failureType, failureCode, message);
     }

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/exception/NoStackIllegalStateException.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/exception/NoStackIllegalStateException.java
@@ -1,0 +1,26 @@
+package org.swisspush.gateleen.core.exception;
+
+public class NoStackIllegalStateException extends IllegalStateException {
+
+    public NoStackIllegalStateException() {
+        super();
+    }
+
+    public NoStackIllegalStateException(String s) {
+        super(s);
+    }
+
+    public NoStackIllegalStateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NoStackIllegalStateException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+
+}

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/LocalHttpClient.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/LocalHttpClient.java
@@ -28,6 +28,6 @@ public class LocalHttpClient extends AbstractHttpClient {
 
     @Override
     protected HttpClientRequest doRequest(HttpMethod method, String uri) {
-        return new LocalHttpClientRequest(method, uri, vertx, wrappedRoutingContexttHandler, exceptionFactory, new LocalHttpServerResponse(vertx));
+        return new LocalHttpClientRequest(method, uri, vertx, wrappedRoutingContexttHandler, exceptionFactory, new LocalHttpServerResponse(vertx, exceptionFactory));
     }
 }

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/LocalHttpServerResponse.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/LocalHttpServerResponse.java
@@ -216,7 +216,7 @@ public class LocalHttpServerResponse extends BufferBridge implements FastFailHtt
         if (!chunked && !headers.contains(HttpHeaders.CONTENT_LENGTH)) {
             IllegalStateException ex = new IllegalStateException("You must set the Content-Length header to be the total size of the message "
                     + "body BEFORE sending any data if you are not using HTTP chunked encoding.");
-            logger.error("non-proper HttpServerResponse occured", ex);
+            logger.debug("non-proper HttpServerResponse occured", ex);
             throw ex;
         }
         ensureBound();

--- a/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/LocalHttpServerResponse.java
+++ b/gateleen-core/src/main/java/org/swisspush/gateleen/core/http/LocalHttpServerResponse.java
@@ -6,6 +6,7 @@ import io.vertx.core.http.*;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.swisspush.gateleen.core.exception.GateleenExceptionFactory;
 import org.swisspush.gateleen.core.util.StatusCode;
 
 /**
@@ -16,6 +17,7 @@ import org.swisspush.gateleen.core.util.StatusCode;
 public class LocalHttpServerResponse extends BufferBridge implements FastFailHttpServerResponse {
 
     private static final Logger logger = LoggerFactory.getLogger(LocalHttpServerResponse.class);
+    private final GateleenExceptionFactory exceptionFactory;
     private int statusCode;
     private String statusMessage;
     private static final String EMPTY = "";
@@ -118,8 +120,9 @@ public class LocalHttpServerResponse extends BufferBridge implements FastFailHtt
     };
 
 
-    public LocalHttpServerResponse(Vertx vertx) {
+    public LocalHttpServerResponse(Vertx vertx, GateleenExceptionFactory exceptionFactory) {
         super(vertx);
+        this.exceptionFactory = exceptionFactory;
         // Attach most simple possible exception handler to base.
         setExceptionHandler(thr -> logger.error("Processing of response failed.", thr));
     }
@@ -214,9 +217,10 @@ public class LocalHttpServerResponse extends BufferBridge implements FastFailHtt
     public Future<Void> write(Buffer data) {
         // emulate Vertx's HttpServerResponseImpl
         if (!chunked && !headers.contains(HttpHeaders.CONTENT_LENGTH)) {
-            IllegalStateException ex = new IllegalStateException("You must set the Content-Length header to be the total size of the message "
+            IllegalStateException ex = exceptionFactory.newIllegalStateException(""
+                    + "You must set the Content-Length header to be the total size of the message "
                     + "body BEFORE sending any data if you are not using HTTP chunked encoding.");
-            logger.debug("non-proper HttpServerResponse occured", ex);
+            logger.debug("non-proper HttpServerResponse occurred", ex);
             throw ex;
         }
         ensureBound();

--- a/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/queuing/QueueProcessorTest.java
+++ b/gateleen-queue/src/test/java/org/swisspush/gateleen/queue/queuing/QueueProcessorTest.java
@@ -217,7 +217,7 @@ public class QueueProcessorTest {
             String url = (String) invocation.getArguments()[1];
             LocalHttpClientRequest request = new LocalHttpClientRequest(httpMethod, url, vertx, event -> {
 
-            }, exceptionFactory, new LocalHttpServerResponse(vertx)) {
+            }, exceptionFactory, new LocalHttpServerResponse(vertx, exceptionFactory)) {
                 @Override
                 public HttpClientRequest response(Handler<AsyncResult<HttpClientResponse>> handler) {
                     FastFaiHttpClientResponse response = new FastFaiHttpClientResponse() {


### PR DESCRIPTION
Here an example where we see that the SAME error is reported TWICE, without adding anything helpful:

```
2024-05-27T02:15:18,228 prod houston ERROR LocalHttpServerResponse - non-proper HttpServerResponse occured
java.lang.IllegalStateException: You must set the Content-Length header to be the total size of the message body BEFORE sending any data if you are not using HTTP chunked encoding.
	at org.swisspush.gateleen.core.http.LocalHttpServerResponse.write(LocalHttpServerResponse.java:221) ~[gateleen-core-2.0.2.jar:?]
	at org.swisspush.gateleen.core.http.LocalHttpServerResponse.write(LocalHttpServerResponse.java:20) ~[gateleen-core-2.0.2.jar:?]
	at org.swisspush.gateleen.logging.LoggingWriteStream.write(LoggingWriteStream.java:47) ~[gateleen-logging-2.0.2.jar:?]
	at org.swisspush.gateleen.logging.LoggingWriteStream.write(LoggingWriteStream.java:39) ~[gateleen-logging-2.0.2.jar:?]
	at org.swisspush.gateleen.logging.LoggingWriteStream.write(LoggingWriteStream.java:13) ~[gateleen-logging-2.0.2.jar:?]
	at io.vertx.core.streams.impl.PumpImpl.lambda$new$1(PumpImpl.java:63) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.HttpEventHandler.handleChunk(HttpEventHandler.java:51) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.HttpClientResponseImpl.handleChunk(HttpClientResponseImpl.java:239) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.Http1xClientConnection$StreamImpl.lambda$new$0(Http1xClientConnection.java:386) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.streams.impl.InboundBuffer.handleEvent(InboundBuffer.java:240) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.streams.impl.InboundBuffer.write(InboundBuffer.java:130) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.Http1xClientConnection$StreamImpl.handleChunk(Http1xClientConnection.java:589) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:71) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.impl.DuplicatedContext.execute(DuplicatedContext.java:163) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.Http1xClientConnection.handleResponseChunk(Http1xClientConnection.java:800) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.Http1xClientConnection.handleHttpMessage(Http1xClientConnection.java:696) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.Http1xClientConnection.handleMessage(Http1xClientConnection.java:663) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.net.impl.ConnectionBase.read(ConnectionBase.java:156) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:153) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) ~[netty-codec-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) ~[netty-codec-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1372) ~[netty-handler-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1235) ~[netty-handler-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1284) ~[netty-handler-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:507) ~[netty-codec-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:446) ~[netty-codec-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276) ~[netty-codec-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) ~[netty-common-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.69.Final.jar:4.1.69.Final]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
2024-05-27T02:15:18,229 prod houston ERROR ContextImpl - Unhandled exception
java.lang.IllegalStateException: You must set the Content-Length header to be the total size of the message body BEFORE sending any data if you are not using HTTP chunked encoding.
	at org.swisspush.gateleen.core.http.LocalHttpServerResponse.write(LocalHttpServerResponse.java:221) ~[gateleen-core-2.0.2.jar:?]
	at org.swisspush.gateleen.core.http.LocalHttpServerResponse.write(LocalHttpServerResponse.java:20) ~[gateleen-core-2.0.2.jar:?]
	at org.swisspush.gateleen.logging.LoggingWriteStream.write(LoggingWriteStream.java:47) ~[gateleen-logging-2.0.2.jar:?]
	at org.swisspush.gateleen.logging.LoggingWriteStream.write(LoggingWriteStream.java:39) ~[gateleen-logging-2.0.2.jar:?]
	at org.swisspush.gateleen.logging.LoggingWriteStream.write(LoggingWriteStream.java:13) ~[gateleen-logging-2.0.2.jar:?]
	at io.vertx.core.streams.impl.PumpImpl.lambda$new$1(PumpImpl.java:63) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.HttpEventHandler.handleChunk(HttpEventHandler.java:51) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.HttpClientResponseImpl.handleChunk(HttpClientResponseImpl.java:239) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.Http1xClientConnection$StreamImpl.lambda$new$0(Http1xClientConnection.java:386) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.streams.impl.InboundBuffer.handleEvent(InboundBuffer.java:240) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.streams.impl.InboundBuffer.write(InboundBuffer.java:130) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.Http1xClientConnection$StreamImpl.handleChunk(Http1xClientConnection.java:589) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:71) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.impl.DuplicatedContext.execute(DuplicatedContext.java:163) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.Http1xClientConnection.handleResponseChunk(Http1xClientConnection.java:800) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.Http1xClientConnection.handleHttpMessage(Http1xClientConnection.java:696) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.http.impl.Http1xClientConnection.handleMessage(Http1xClientConnection.java:663) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.net.impl.ConnectionBase.read(ConnectionBase.java:156) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:153) ~[vertx-core-4.2.1.jar:4.2.1]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) ~[netty-codec-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) ~[netty-codec-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1372) ~[netty-handler-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1235) ~[netty-handler-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1284) ~[netty-handler-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:507) ~[netty-codec-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:446) ~[netty-codec-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276) ~[netty-codec-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493) ~[netty-transport-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) ~[netty-common-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.69.Final.jar:4.1.69.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.69.Final.jar:4.1.69.Final]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]

```