### PR TITLE
Avoid usage of metrics where a history is kept

### DIFF
--- a/gateleen-monitoring/src/main/java/org/swisspush/gateleen/monitoring/MonitoringHandler.java
+++ b/gateleen-monitoring/src/main/java/org/swisspush/gateleen/monitoring/MonitoringHandler.java
@@ -353,7 +353,7 @@ public class MonitoringHandler {
             if (metricName != null) {
                 double duration = (System.nanoTime() - startTime) / 1000000d;
                 vertx.eventBus().publish(getMonitoringAddress(),
-                        new JsonObject().put(METRIC_NAME, prefix + "routing." + metricName + ".duration").put(METRIC_ACTION, "update").put("n", duration));
+                        new JsonObject().put(METRIC_NAME, prefix + "routing." + metricName + ".duration").put(METRIC_ACTION, "set").put("n", duration));
             }
             updatePendingRequestCount(false);
         }
@@ -389,7 +389,7 @@ public class MonitoringHandler {
         vertx.eventBus().request(getRedisquesAddress(), buildGetQueueItemsCountOperation(queue), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
             if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
                 final long count = reply.result().body().getLong(VALUE);
-                vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + LAST_USED_QUEUE_SIZE_METRIC).put(METRIC_ACTION, "update").put("n", count));
+                vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + LAST_USED_QUEUE_SIZE_METRIC).put(METRIC_ACTION, "set").put("n", count));
             } else {
                 log.error("Error gathering queue size for queue '{}'", queue);
             }

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/core/monitoring/MonitoringTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/core/monitoring/MonitoringTest.java
@@ -29,10 +29,6 @@ import static io.restassured.RestAssured.*;
 @RunWith(VertxUnitRunner.class)
 public class MonitoringTest extends AbstractTest {
     Logger log = LoggerFactory.getLogger(MonitoringTest.class);
-
-    private static final long MAX_DURATION_THRESHOLD = 100;
-    private static final double MEAN_DURATION_THRESHOLD = 25.0;
-
     /**
      * Overwrite RestAssured configuration
      */
@@ -95,17 +91,7 @@ public class MonitoringTest extends AbstractTest {
 
         // read the jmx infos
         if (mbs.isRegistered(beanNameObject)) {
-            log.info(" > Min:    {}", mbs.getAttribute(beanNameObject, "Min"));
-            log.info(" > Mean:   {}", mbs.getAttribute(beanNameObject, "Mean"));
-            log.info(" > Max:    {}", mbs.getAttribute(beanNameObject, "Max"));
-            log.info(" > Count:  {}", mbs.getAttribute(beanNameObject, "Count"));
-            log.info(" > StdDev: {}", mbs.getAttribute(beanNameObject, "StdDev"));
-
-            // check max threshold
-            context.assertTrue((Long) mbs.getAttribute(beanNameObject, "Max") <= MAX_DURATION_THRESHOLD, "'Max' should be below the threshold");
-
-            // checm mean threshold
-            context.assertTrue((Double) mbs.getAttribute(beanNameObject, "Mean") <= MEAN_DURATION_THRESHOLD, "'Mean' should be below the threshold");
+            log.info(" > Value:    {}", mbs.getAttribute(beanNameObject, "Value"));
         } else {
             context.fail("could not found mbean " + beanName);
         }

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/HookQueueingStrategiesTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/HookQueueingStrategiesTest.java
@@ -78,18 +78,18 @@ public class HookQueueingStrategiesTest extends AbstractTest {
         when().get("pushnotification/queuing/queues/")
                 .then().assertThat()
                 .body("queues", hasItem(queueName));
-        given().urlEncodingEnabled(true).when().get("pushnotification/queuing/queues/" + queueName)
+        given().urlEncodingEnabled(false).when().get("pushnotification/queuing/queues/" + queueName)
                 .then().assertThat()
                 .body(queueName, hasSize(3));
 
         // check that no queue items do have a payload
-        String responseIndex0 = given().urlEncodingEnabled(true)
+        String responseIndex0 = given().urlEncodingEnabled(false)
                 .when().get("pushnotification/queuing/queues/" + queueName + "/0")
                 .then().extract().response().asString();
-        String responseIndex1 = given().urlEncodingEnabled(true)
+        String responseIndex1 = given().urlEncodingEnabled(false)
                 .when().get("pushnotification/queuing/queues/" + queueName + "/1")
                 .then().extract().response().asString();
-        String responseIndex2 = given().urlEncodingEnabled(true)
+        String responseIndex2 = given().urlEncodingEnabled(false)
                 .when().get("pushnotification/queuing/queues/" + queueName + "/2")
                 .then().extract().response().asString();
 
@@ -147,7 +147,7 @@ public class HookQueueingStrategiesTest extends AbstractTest {
                 .then().assertThat()
                 .body("queues", hasItem(queueName))
                 .body("queues", not(hasItem(managerQueue)));
-        given().urlEncodingEnabled(true).when().get("pushnotification/queuing/queues/" + queueName)
+        given().urlEncodingEnabled(false).when().get("pushnotification/queuing/queues/" + queueName)
                 .then().assertThat()
                 .body(queueName, hasSize(3));
         when().get("pushnotification/queuing/locks/")
@@ -158,10 +158,10 @@ public class HookQueueingStrategiesTest extends AbstractTest {
         // after 5s an unlocked manager queue with a single queue item should exist and the original queue should be empty
         // and its lock should have been deleted
         Awaitility.await().untilAsserted(() -> when().get("pushnotification/queuing/queues/").then().assertThat().body("queues", hasItem(managerQueue)));
-        given().urlEncodingEnabled(true).when().get("pushnotification/queuing/queues/" + managerQueue)
+        given().urlEncodingEnabled(false).when().get("pushnotification/queuing/queues/" + managerQueue)
                 .then().assertThat()
                 .body(managerQueue, hasSize(1));
-        given().urlEncodingEnabled(true).when().get("pushnotification/queuing/queues/" + queueName)
+        given().urlEncodingEnabled(false).when().get("pushnotification/queuing/queues/" + queueName)
                 .then().assertThat()
                 .body(queueName, empty());
 
@@ -181,7 +181,7 @@ public class HookQueueingStrategiesTest extends AbstractTest {
                 .then().assertThat()
                 .body("queues", hasItem(queueName))
                 .body("queues", hasItem(managerQueue));
-        given().urlEncodingEnabled(true).when().get("pushnotification/queuing/queues/" + queueName)
+        given().urlEncodingEnabled(false).when().get("pushnotification/queuing/queues/" + queueName)
                 .then().assertThat()
                 .body(queueName, hasSize(2));
         when().get("pushnotification/queuing/locks/")
@@ -193,10 +193,10 @@ public class HookQueueingStrategiesTest extends AbstractTest {
         // and its lock should have been deleted
         TestUtils.waitSomeTime(5);
         Awaitility.await().untilAsserted(() -> when().get("pushnotification/queuing/queues/").then().assertThat().body("queues", hasItem(managerQueue)));
-        given().urlEncodingEnabled(true).when().get("pushnotification/queuing/queues/" + managerQueue)
+        given().urlEncodingEnabled(false).when().get("pushnotification/queuing/queues/" + managerQueue)
                 .then().assertThat()
                 .body(managerQueue, hasSize(1));
-        given().urlEncodingEnabled(true).when().get("pushnotification/queuing/queues/" + queueName)
+        given().urlEncodingEnabled(false).when().get("pushnotification/queuing/queues/" + queueName)
                 .then().assertThat()
                 .body(queueName, empty());
 


### PR DESCRIPTION
Refer to

https://github.com/swisspost/mod-metrics/blob/develop/src/main/java/org/swisspush/metrics/MetricsModule.java#L86-L106

The purpose of this PR is to find out we  use a Gauge instead of a Histogram for "duration" metrics and also for some queue counter in order to reduce the memory foot print. The impact will be that we only have a simple counter here

<img width="370" alt="image" src="https://github.com/user-attachments/assets/ce7ca334-1d48-4b0d-9aaa-0406cf0c8b64">

compared to

<img width="443" alt="image" src="https://github.com/user-attachments/assets/5d4dbb86-a8d7-4b16-b394-3517a5d578fb">


