### PR TITLE
Consider x-timeout HTTP header upon queue item dequeuing

### DIFF
--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueueProcessor.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueueProcessor.java
@@ -292,7 +292,13 @@ public class QueueProcessor {
                     performCircuitBreakerActions(queueName, queuedRequest, FAILURE, state);
                 });
             };
-            request1.idleTimeout(120000); // avoids blocking other requests
+
+            if (queuedRequest.getHeaders().get("x-timeout") != null && !queuedRequest.getHeaders().get("x-timeout").isEmpty()) {
+                request1.idleTimeout((long) (Long.parseLong(queuedRequest.getHeaders().get("x-timeout")) * 1.1));
+            } else {
+                request1.idleTimeout(120000); // avoids blocking other requests
+            }
+
             if (queuedRequest.getPayload() != null) {
                 vertx.<Buffer>executeBlocking(() -> {
                     long beginEpchMs = currentTimeMillis();


### PR DESCRIPTION
With this PR we use the value provided in HTTP header x-timeout when set. If not, then we default to 120s as before.

Here logs from a case where the header is not set and a timeout occurred after 30s (the 120s idle timeout set has no impact here reallly)

Line 16846: 16:02:25,344 TRACE org.swisspush.gateleen.queue.queuing.QueueProcessor                     - vert.x-eventloop-thread-1 - %1WbV 03f78f18f1277b04e28a5f672d50e03e process message: io.vertx.core.eventbus.impl.MessageImpl@5d72eb03
Line 16848: 16:02:25,344 DEBUG org.swisspush.gateleen.queue.queuing.QueueProcessor                     - vert.x-eventloop-thread-1 - %1WbV 03f78f18f1277b04e28a5f672d50e03e performing request POST /houston/preflux/executeTask/localhost/123/DOCKER_PULL
Line 16850: 16:02:25,344 DEBUG org.swisspush.gateleen.queue.queuing.QueueProcessor                     - vert.x-eventloop-thread-1 - %1WbV 03f78f18f1277b04e28a5f672d50e03e performing request POST /houston/preflux/executeTask/localhost/123/DOCKER_PULL using idle timeout 120000
Line 16866: 16:02:55,349 ERROR org.swisspush.gateleen.routing.Forwarder                                - vert.x-eventloop-thread-1 - %1WbV 03f78f18f1277b04e28a5f672d50e03e http://10.0.20.2:7021/preflux/preflux/executeTask/localhost/123/DOCKER_PULL The timeout period of 30000ms has been exceeded while executing POST /preflux/preflux/executeTask/localhost/123/DOCKER_PULL for server null
Line 16868: 16:02:55,350 TRACE org.swisspush.gateleen.queue.queuing.QueueProcessor                     - vert.x-eventloop-thread-1 - %1WbV 03f78f18f1277b04e28a5f672d50e03e response: 500




and here a log where x-timeout was set to 140s

Line 14226: 15:54:03,507 TRACE org.swisspush.gateleen.queue.queuing.QueueProcessor                     - vert.x-eventloop-thread-1 - %VoKt a334b6992d609dd8ae33d8db1dffee8f process message: io.vertx.core.eventbus.impl.MessageImpl@147c8642
Line 14232: 15:54:03,507 DEBUG org.swisspush.gateleen.queue.queuing.QueueProcessor                     - vert.x-eventloop-thread-1 - %VoKt a334b6992d609dd8ae33d8db1dffee8f performing request POST /houston/preflux/executeTask/localhost/123/DOCKER_PULL
Line 14242: 15:54:03,507 DEBUG org.swisspush.gateleen.queue.queuing.QueueProcessor                     - vert.x-eventloop-thread-1 - %VoKt a334b6992d609dd8ae33d8db1dffee8f performing request POST /houston/preflux/executeTask/localhost/123/DOCKER_PULL using idle timeout 140000
Line 14908: 15:56:23,520 ERROR org.swisspush.gateleen.routing.Forwarder                                - vert.x-eventloop-thread-1 - %VoKt a334b6992d609dd8ae33d8db1dffee8f http://10.0.20.2:7021/preflux/preflux/executeTask/localhost/123/DOCKER_PULL The timeout period of 140000ms has been exceeded while executing POST /preflux/preflux/executeTask/localhost/123/DOCKER_PULL for server null
Line 14910: 15:56:23,520 TRACE org.swisspush.gateleen.queue.queuing.QueueProcessor                     - vert.x-eventloop-thread-1 - %VoKt a334b6992d609dd8ae33d8db1dffee8f response: 500
Line 14912: 15:56:23,520  INFO org.swisspush.gateleen.queue.queuing.QueueProcessor                     - vert.x-eventloop-thread-1 - %VoKt a334b6992d609dd8ae33d8db1dffee8f Failed queued request to /houston/preflux/executeTask/localhost/123/DOCKER_PULL: 500 The timeout period of 140000ms has been exceeded while executing POST /preflux/preflux/executeTask/localhost/123/DOCKER_PULL for server null
Line 14914: 15:56:23,520 DEBUG org.swisspush.gateleen.queue.queuing.QueueProcessor                     - vert.x-eventloop-thread-1 - %VoKt a334b6992d609dd8ae33d8db1dffee8f Backend response end
