### PR TITLE
Issue311 improve hook searching

### DIFF
--- a/gateleen-hook/README_hook.md
+++ b/gateleen-hook/README_hook.md
@@ -248,7 +248,7 @@ Gateleen allows searching for listeners and routes using the query parameter `q`
 Search for listeners based on a query parameter like this:
 
 ```
-GET http://myserver:7012/gateleen/server/listenertest/_hooks/listeners?q=test
+GET http://myserver:7012/playground/server/hooks/v1/registrations/listeners?q=test
 ```
 
 The response will contain the matching listeners. If no match is found, an empty list is returned:
@@ -273,7 +273,7 @@ The response will contain the matching listeners. If no match is found, an empty
 Similarly, you can search for routes using a query parameter:
 
 ```
-GET http://myserver:7012/gateleen/server/routetest/_hooks/routes?q=test
+GET http://myserver:7012/playground/server/hooks/v1/registrations/routes/?q=test
 ```
 
 The response contains the matching routes, or an empty list if no match is found.

--- a/gateleen-hook/README_hook.md
+++ b/gateleen-hook/README_hook.md
@@ -240,10 +240,43 @@ hookHandler.enableResourceLogging(true);
 ```
 
 
+## Query-Based Listener and Route Search
 
+Gateleen allows searching for listeners and routes using the query parameter `q`. This simplifies filtering the registered hooks based on query parameters.
 
+### Listener Search with `q`
+Search for listeners based on a query parameter like this:
 
+```
+GET http://myserver:7012/gateleen/server/listenertest/_hooks/listeners/listener/1?q=testQuery
+```
 
+The response will contain the matching listeners. If no match is found, an empty list is returned:
 
+**Example response with matches:**
+```json
+{
+  "listeners": [
+    {
+      "destination": "/path/to/destination",
+      "methods": ["GET", "POST"]
+    }
+  ]
+}
+```
 
+**Example response with no matches:**
+```json
+{
+  "listeners": []
+}
+```
 
+### Route Search with `q`
+Similarly, you can search for routes using a query parameter:
+
+```
+GET http://myserver:7012/gateleen/server/listenertest/_hooks/routes?q=testRoute
+```
+
+The response contains the matching routes, or an empty list if no match is found.

--- a/gateleen-hook/README_hook.md
+++ b/gateleen-hook/README_hook.md
@@ -244,11 +244,13 @@ hookHandler.enableResourceLogging(true);
 
 Gateleen allows searching for listeners and routes using the query parameter `q`. This simplifies filtering the registered hooks based on query parameters.
 
+The search will be based on the value registered of the destination property
+
 ### Listener Search with `q`
 Search for listeners based on a query parameter like this:
 
 ```
-GET http://myserver:7012/playground/server/hooks/v1/registrations/listeners?q=test
+GET http://myserver:7012/playground/server/hooks/v1/registrations/listeners?q=mylistener
 ```
 
 The response will contain the matching listeners. If no match is found, an empty list is returned:
@@ -257,7 +259,7 @@ The response will contain the matching listeners. If no match is found, an empty
 ```json
 {
   "listeners": [
-    "first+playground+server+test+nemo+origin+b"
+    "first+playground+server+test+nemo+origin+mylistener"
   ]
 }
 ```
@@ -273,7 +275,23 @@ The response will contain the matching listeners. If no match is found, an empty
 Similarly, you can search for routes using a query parameter:
 
 ```
-GET http://myserver:7012/playground/server/hooks/v1/registrations/routes/?q=test
+GET http://myserver:7012/playground/server/hooks/v1/registrations/routes/?q=myroute
 ```
 
 The response contains the matching routes, or an empty list if no match is found.
+
+**Example response with matches:**
+```json
+{
+  "routes": [
+    "first+playground+server+test+nemo+origin+myroute"
+  ]
+}
+
+```
+**Example response with no matches:**
+```json
+{
+  "routes": []
+}
+```

--- a/gateleen-hook/README_hook.md
+++ b/gateleen-hook/README_hook.md
@@ -257,10 +257,7 @@ The response will contain the matching listeners. If no match is found, an empty
 ```json
 {
   "listeners": [
-    {
-      "destination": "/path/to/destination",
-      "methods": ["GET", "POST"]
-    }
+    "first+playground+server+test+nemo+origin+b"
   ]
 }
 ```

--- a/gateleen-hook/README_hook.md
+++ b/gateleen-hook/README_hook.md
@@ -248,7 +248,7 @@ Gateleen allows searching for listeners and routes using the query parameter `q`
 Search for listeners based on a query parameter like this:
 
 ```
-GET http://myserver:7012/gateleen/server/listenertest/_hooks/listeners/listener/1?q=testQuery
+GET http://myserver:7012/gateleen/server/listenertest/_hooks/listeners?q=testQuery
 ```
 
 The response will contain the matching listeners. If no match is found, an empty list is returned:

--- a/gateleen-hook/README_hook.md
+++ b/gateleen-hook/README_hook.md
@@ -248,7 +248,7 @@ Gateleen allows searching for listeners and routes using the query parameter `q`
 Search for listeners based on a query parameter like this:
 
 ```
-GET http://myserver:7012/gateleen/server/listenertest/_hooks/listeners?q=testQuery
+GET http://myserver:7012/gateleen/server/listenertest/_hooks/listeners?q=test
 ```
 
 The response will contain the matching listeners. If no match is found, an empty list is returned:
@@ -273,7 +273,7 @@ The response will contain the matching listeners. If no match is found, an empty
 Similarly, you can search for routes using a query parameter:
 
 ```
-GET http://myserver:7012/gateleen/server/listenertest/_hooks/routes?q=testRoute
+GET http://myserver:7012/gateleen/server/routetest/_hooks/routes?q=test
 ```
 
 The response contains the matching routes, or an empty list if no match is found.

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -583,10 +583,10 @@ public class HookHandler implements LoggableResource {
             String queryParam = request.getParam("q");
             // 2. Check if the URI is for listeners or routes and has a query parameter
             if (queryParam != null && !queryParam.isEmpty()) {
-                if (uri.contains(HOOK_LISTENER_STORAGE_PATH)) {
+                if (uri.contains(LISTENERS_KEY)) {
                     handleListenerSearch(queryParam, request.response());
                     return true;
-                } else if (uri.contains(HOOK_ROUTE_STORAGE_PATH)) {
+                } else if (uri.contains(ROUTES_KEY)) {
                     handleRouteSearch(queryParam, request.response());
                     return true;
                 }
@@ -649,11 +649,15 @@ public class HookHandler implements LoggableResource {
         JsonObject result = new JsonObject();
         result.put(resultKey, matchingResults);
 
-        // Set headers safely before writing the response
-        response.putHeader(CONTENT_TYPE_HEADER, CONTENT_TYPE_JSON);
-        response.write(result.encode());
-        response.end();
+        String encodedResult = result.encode(); // Convert the result to a string
 
+        // Set Content-Length header before sending the response
+        response.putHeader(CONTENT_TYPE_HEADER, CONTENT_TYPE_JSON);
+        response.putHeader("Content-Length", String.valueOf(encodedResult.length())); // Set content length
+
+        // Write and end the response
+        response.write(encodedResult);
+        response.end();
     }
 
     /**

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -581,7 +581,6 @@ public class HookHandler implements LoggableResource {
         if (request.method() == HttpMethod.GET) {
             String uri = request.uri();
             String queryParam = request.getParam("q");
-
             // 2. Check if the URI is for listeners or routes and has a query parameter
             if (queryParam != null && !queryParam.isEmpty()) {
                 if (uri.contains(HOOK_LISTENER_STORAGE_PATH)) {
@@ -591,9 +590,6 @@ public class HookHandler implements LoggableResource {
                     handleRouteSearch(queryParam, request.response());
                     return true;
                 }
-            }
-            else {
-                return false;
             }
         }
 

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -570,7 +570,6 @@ public class HookHandler implements LoggableResource {
             }
         }
 
-        // 1. Check if the request method is GET
         if (requestMethod == GET && !request.params().isEmpty()) {
             String queryParam = request.getParam("q");
             String normalizedRequestUri = requestUri.replaceAll("/$", "");
@@ -628,11 +627,10 @@ public class HookHandler implements LoggableResource {
 
     /**
      * Search the repository for items matching the query parameter.
-     * Returns a JSON response with the matched results.
-     * If any essential parameter (repository, response, getDestination) is null,
-     * a 400 Bad Request is returned.
-     *
-     * @param repository The items to search.
+     * Output a JSON response with the matched results.
+     * If parameter queryParam is empty or null a 400 Bad Request is returned.
+     * All params cannot be null
+     * @param repository The items to search .
      * @param getDestination Function to extract destinations.
      * @param queryParam The query string to match.
      * @param resultKey The key for the result in the response.
@@ -640,7 +638,7 @@ public class HookHandler implements LoggableResource {
      */
     private <T> void handleSearch(Map<String, T> repository, Function<T, String> getDestination, String queryParam, String resultKey, HttpServerResponse response) {
 
-        if (repository == null || getDestination == null || resultKey == null || queryParam == null || queryParam.isEmpty()) {
+        if (queryParam == null || queryParam.isEmpty()) {
             response.setStatusCode(StatusCode.BAD_REQUEST.getStatusCode()).end("Bad Request: One or more required parameters are missing or null");
             return;
         }

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -74,8 +74,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static io.vertx.core.http.HttpMethod.DELETE;
-import static io.vertx.core.http.HttpMethod.PUT;
+import static io.vertx.core.http.HttpMethod.*;
 import static org.swisspush.gateleen.core.util.HttpRequestHeader.CONTENT_LENGTH;
 
 /**
@@ -572,17 +571,15 @@ public class HookHandler implements LoggableResource {
         }
 
         // 1. Check if the request method is GET
-        if (request.method() == HttpMethod.GET) {
-            if (!request.params().isEmpty()) {
-                String queryParam = request.getParam("q");
-                String normalizedRequestUri = requestUri.replaceAll("/$", "");
-                if (normalizedRequestUri.contains(listenerBase.replaceAll("/$", ""))) {
-                    handleListenerSearch(queryParam, request.response());
-                    return true;
-                } else if (normalizedRequestUri.contains(routeBase.replaceAll("/$", ""))) {
-                    handleRouteSearch(queryParam, request.response());
-                    return true;
-                }
+        if (requestMethod == GET && !request.params().isEmpty()) {
+            String queryParam = request.getParam("q");
+            String normalizedRequestUri = requestUri.replaceAll("/$", "");
+            if (normalizedRequestUri.contains(listenerBase.replaceAll("/$", ""))) {
+                handleListenerSearch(queryParam, request.response());
+                return true;
+            } else if (normalizedRequestUri.contains(routeBase.replaceAll("/$", ""))) {
+                handleRouteSearch(queryParam, request.response());
+                return true;
             }
         }
 

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/HookHandler.java
@@ -570,10 +570,14 @@ public class HookHandler implements LoggableResource {
         }
 
         HttpServerResponse response = ctx.response();
-        String queryParam = request.getParam("q");
+        String queryParam = null;
 
-        if ((queryParam != null) && !queryParam.isEmpty()) {
-            this.handleHookSearch(queryParam,response);
+        if (request.params() != null) {
+            queryParam = request.getParam("q");
+        }
+
+        if (queryParam != null && !queryParam.isEmpty()) {
+            this.handleHookSearch(queryParam, response);
             return true;
         }
 

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
@@ -49,6 +49,7 @@ public class Route {
     private MonitoringHandler monitoringHandler;
     private String userProfilePath;
     private ResourceStorage storage;
+    private String hookIdentify;
 
     private String urlPattern;
     private HttpHook httpHook;
@@ -79,7 +80,7 @@ public class Route {
      * @param urlPattern - this can be a listener or a normal urlPattern (eg. for a route)
      */
     public Route(Vertx vertx, ResourceStorage storage, LoggingResourceManager loggingResourceManager, LogAppenderRepository logAppenderRepository,
-                 MonitoringHandler monitoringHandler, String userProfilePath, HttpHook httpHook, String urlPattern, HttpClient selfClient) {
+                 MonitoringHandler monitoringHandler, String userProfilePath, HttpHook httpHook, String urlPattern, HttpClient selfClient, String hookIdentify) {
         this.vertx = vertx;
         this.storage = storage;
         this.loggingResourceManager = loggingResourceManager;
@@ -89,6 +90,7 @@ public class Route {
         this.httpHook = httpHook;
         this.urlPattern = urlPattern;
         this.selfClient = selfClient;
+        this.hookIdentify = hookIdentify;
 
         createRule();
 
@@ -272,5 +274,9 @@ public class Route {
      */
     public HttpHook getHook() {
         return httpHook;
+    }
+
+    public String getHookIdentify() {
+        return hookIdentify;
     }
 }

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
@@ -49,7 +49,7 @@ public class Route {
     private MonitoringHandler monitoringHandler;
     private String userProfilePath;
     private ResourceStorage storage;
-    private String hookIdentify;
+    private String hookDisplayText;
 
     private String urlPattern;
     private HttpHook httpHook;
@@ -79,8 +79,9 @@ public class Route {
      * @param httpHook httpHook
      * @param urlPattern - this can be a listener or a normal urlPattern (eg. for a route)
      */
-    public Route(Vertx vertx, ResourceStorage storage, LoggingResourceManager loggingResourceManager, LogAppenderRepository logAppenderRepository,
-                 MonitoringHandler monitoringHandler, String userProfilePath, HttpHook httpHook, String urlPattern, HttpClient selfClient, String hookIdentify) {
+    public Route(Vertx vertx, ResourceStorage storage, LoggingResourceManager loggingResourceManager,
+                 LogAppenderRepository logAppenderRepository, MonitoringHandler monitoringHandler, String userProfilePath,
+                 HttpHook httpHook, String urlPattern, HttpClient selfClient, String hookDisplayText) {
         this.vertx = vertx;
         this.storage = storage;
         this.loggingResourceManager = loggingResourceManager;
@@ -90,7 +91,7 @@ public class Route {
         this.httpHook = httpHook;
         this.urlPattern = urlPattern;
         this.selfClient = selfClient;
-        this.hookIdentify = hookIdentify;
+        this.hookDisplayText = hookDisplayText;
 
         createRule();
 
@@ -276,7 +277,7 @@ public class Route {
         return httpHook;
     }
 
-    public String getHookIdentify() {
-        return hookIdentify;
+    public String getHookDisplayText() {
+        return hookDisplayText;
     }
 }

--- a/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
+++ b/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
@@ -896,7 +896,7 @@ public class HookHandlerTest {
     @Test
     public void testHandleGETRequestWithTrailingSlash(TestContext testContext) {
         // Define URI with trailing slash and configure the request
-        GETRequest request = new GETRequest(HOOK_LISTENER_URI, mockResponse);
+        GETRequest request = new GETRequest(HOOK_LISTENER_URI+"/", mockResponse);
         request.addParameter("q", "validQueryParam");
 
         // Mock the RoutingContext

--- a/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
+++ b/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
@@ -78,7 +78,7 @@ public class HookHandlerTest {
         requestQueue = mock(RequestQueue.class);
         reducedPropagationManager = mock(ReducedPropagationManager.class);
         hookHandler = new HookHandler(vertx, httpClient, storage, loggingResourceManager, logAppenderRepository,
-                monitoringHandler, "userProfilePath", "hookRootURI/", requestQueue, false, reducedPropagationManager);
+                monitoringHandler, "userProfilePath", HOOK_ROOT_URI, requestQueue, false, reducedPropagationManager);
         hookHandler.init();
     }
 

--- a/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
+++ b/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
@@ -8,6 +8,7 @@ import io.vertx.core.http.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.HostAndPort;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.RoutingContext;
@@ -19,10 +20,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.swisspush.gateleen.core.http.DummyHttpServerRequest;
-import org.swisspush.gateleen.core.http.DummyHttpServerResponse;
-import org.swisspush.gateleen.core.http.FastFailHttpServerRequest;
-import org.swisspush.gateleen.core.http.FastFailHttpServerResponse;
+import org.swisspush.gateleen.core.http.*;
 import org.swisspush.gateleen.core.storage.MockResourceStorage;
 import org.swisspush.gateleen.hook.reducedpropagation.ReducedPropagationManager;
 import org.swisspush.gateleen.logging.LogAppenderRepository;
@@ -41,8 +39,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.Map;
 
 import static io.vertx.core.http.HttpMethod.PUT;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 import static org.swisspush.gateleen.core.util.HttpRequestHeader.*;
 
 /**
@@ -72,15 +71,15 @@ public class HookHandlerTest {
     @Before
     public void setUp() {
         vertx = Vertx.vertx();
-        routingContext = Mockito.mock(RoutingContext.class);
-        httpClient = Mockito.mock(HttpClient.class);
-        Mockito.when(httpClient.request(any(HttpMethod.class), anyString())).thenReturn(Mockito.mock(Future.class));
+        routingContext = mock(RoutingContext.class);
+        httpClient = mock(HttpClient.class);
+        when(httpClient.request(any(HttpMethod.class), anyString())).thenReturn(mock(Future.class));
         storage = new MockResourceStorage();
-        loggingResourceManager = Mockito.mock(LoggingResourceManager.class);
-        logAppenderRepository = Mockito.mock(LogAppenderRepository.class);
-        monitoringHandler = Mockito.mock(MonitoringHandler.class);
-        requestQueue = Mockito.mock(RequestQueue.class);
-        reducedPropagationManager = Mockito.mock(ReducedPropagationManager.class);
+        loggingResourceManager = mock(LoggingResourceManager.class);
+        logAppenderRepository = mock(LogAppenderRepository.class);
+        monitoringHandler = mock(MonitoringHandler.class);
+        requestQueue = mock(RequestQueue.class);
+        reducedPropagationManager = mock(ReducedPropagationManager.class);
 
 
         hookHandler = new HookHandler(vertx, httpClient, storage, loggingResourceManager, logAppenderRepository, monitoringHandler,
@@ -136,7 +135,7 @@ public class HookHandlerTest {
         PUTRequest putRequest = new PUTRequest(uri, originalPayload);
         putRequest.addHeader(CONTENT_LENGTH.getName(), "99");
 
-        Mockito.when(routingContext.request()).thenReturn(putRequest);
+        when(routingContext.request()).thenReturn(putRequest);
 
         hookHandler.handle(routingContext);
 
@@ -163,7 +162,7 @@ public class HookHandlerTest {
         PUTRequest putRequest = new PUTRequest(uri, originalPayload);
         putRequest.addHeader(CONTENT_LENGTH.getName(), "99");
 
-        Mockito.when(routingContext.request()).thenReturn(putRequest);
+        when(routingContext.request()).thenReturn(putRequest);
         hookHandler.handle(routingContext);
 
         // verify that enqueue has been called WITH the payload
@@ -188,7 +187,7 @@ public class HookHandlerTest {
         String originalPayload = "{\"key\":123}";
         PUTRequest putRequest = new PUTRequest(uri, originalPayload);
         putRequest.addHeader(CONTENT_LENGTH.getName(), "99");
-        Mockito.when(routingContext.request()).thenReturn(putRequest);
+        when(routingContext.request()).thenReturn(putRequest);
         hookHandler.handle(routingContext);
 
         // verify that enqueue has been called WITHOUT the payload but with 'Content-Length : 0' header
@@ -200,7 +199,7 @@ public class HookHandlerTest {
         }), anyString(), any(Handler.class));
 
         PUTRequest putRequestWithoutContentLengthHeader = new PUTRequest(uri, originalPayload);
-        Mockito.when(routingContext.request()).thenReturn(putRequestWithoutContentLengthHeader);
+        when(routingContext.request()).thenReturn(putRequestWithoutContentLengthHeader);
         hookHandler.handle(routingContext);
 
         // verify that enqueue has been called WITHOUT the payload and WITHOUT 'Content-Length' header
@@ -229,7 +228,7 @@ public class HookHandlerTest {
         String originalPayload = "{\"key\":123}";
         PUTRequest putRequest = new PUTRequest(uri, originalPayload);
         putRequest.addHeader(CONTENT_LENGTH.getName(), "99");
-        Mockito.when(routingContext.request()).thenReturn(putRequest);
+        when(routingContext.request()).thenReturn(putRequest);
         hookHandler.handle(routingContext);
 
         // verify that no enqueue (or lockedEnqueue) has been called because no ReducedPropagationManager was configured
@@ -255,7 +254,7 @@ public class HookHandlerTest {
         PUTRequest putRequest = new PUTRequest(uri, originalPayload);
         putRequest.addHeader(CONTENT_LENGTH.getName(), "99");
 
-        Mockito.when(routingContext.request()).thenReturn(putRequest);
+        when(routingContext.request()).thenReturn(putRequest);
         hookHandler.handle(routingContext);
 
         String targetUri = "/playground/server/push/v1/devices/" + deviceId + "/playground/server/tests/hooktest/abc123";
@@ -277,7 +276,7 @@ public class HookHandlerTest {
         PUTRequest putRequest = new PUTRequest(uri, originalPayload);
         putRequest.addHeader(CONTENT_LENGTH.getName(), "99");
 
-        Mockito.when(routingContext.request()).thenReturn(putRequest);
+        when(routingContext.request()).thenReturn(putRequest);
         hookHandler.handle(routingContext);
 
         // verify that enqueue has been called WITH the payload
@@ -304,7 +303,7 @@ public class HookHandlerTest {
         putRequest.addHeader(CONTENT_LENGTH.getName(), "99");
         putRequest.addHeader("x-foo", "A");
 
-        Mockito.when(routingContext.request()).thenReturn(putRequest);
+        when(routingContext.request()).thenReturn(putRequest);
         hookHandler.handle(routingContext);
 
         // verify that enqueue has been called WITH the payload
@@ -329,7 +328,7 @@ public class HookHandlerTest {
         String originalPayload = "{\"key\":123}";
         PUTRequest putRequest = new PUTRequest(uri, originalPayload);
         putRequest.addHeader(CONTENT_LENGTH.getName(), "99");
-        Mockito.when(routingContext.request()).thenReturn(putRequest);
+        when(routingContext.request()).thenReturn(putRequest);
         hookHandler.handle(routingContext);
 
         // verify that no enqueue has been called since the header did not match
@@ -372,7 +371,7 @@ public class HookHandlerTest {
         }
 
         // Trigger work
-        Mockito.when(routingContext.request()).thenReturn(request);
+        when(routingContext.request()).thenReturn(request);
         hookHandler.handle(routingContext);
 
         // Assert request was ok
@@ -408,7 +407,7 @@ public class HookHandlerTest {
         }
 
         // Trigger work
-        Mockito.when(routingContext.request()).thenReturn(request);
+        when(routingContext.request()).thenReturn(request);
         hookHandler.handle(routingContext);
 
         // Assert request was ok
@@ -443,7 +442,7 @@ public class HookHandlerTest {
         }
 
         // Trigger work
-        Mockito.when(routingContext.request()).thenReturn(request);
+        when(routingContext.request()).thenReturn(request);
         hookHandler.handle(routingContext);
 
         // Assert request was ok
@@ -474,7 +473,7 @@ public class HookHandlerTest {
         }
 
         // Trigger work
-        Mockito.when(routingContext.request()).thenReturn(request);
+        when(routingContext.request()).thenReturn(request);
         hookHandler.handle(routingContext);
 
         // Assert request was ok
@@ -505,7 +504,7 @@ public class HookHandlerTest {
         }
 
         // Trigger work
-        Mockito.when(routingContext.request()).thenReturn(request);
+        when(routingContext.request()).thenReturn(request);
         hookHandler.handle(routingContext);
 
         // Assert request was ok
@@ -539,7 +538,7 @@ public class HookHandlerTest {
         }
 
         // Trigger
-        Mockito.when(routingContext.request()).thenReturn(request);
+        when(routingContext.request()).thenReturn(request);
         hookHandler.handle(routingContext);
 
         { // Assert request got accepted.
@@ -575,7 +574,7 @@ public class HookHandlerTest {
             }
 
             // Trigger
-            Mockito.when(routingContext.request()).thenReturn(request);
+            when(routingContext.request()).thenReturn(request);
             hookHandler.handle(routingContext);
 
             { // Assert request got rejected.
@@ -645,141 +644,128 @@ public class HookHandlerTest {
     }
 
     @Test
-    public void testHookHandleSearchWithMatchingRoutesAndListeners(TestContext context) throws Exception {
-        // Mock the response
-        HttpServerResponse response = Mockito.mock(HttpServerResponse.class);
-        Mockito.when(response.putHeader(anyString(), anyString())).thenReturn(response);
+    public void testHandleListenerSearch_Success() {
+        // Arrange
+        String queryParam = "validQueryParam";
+        String uri = "registrations/listeners/?q=" + queryParam;
 
-        // Mock the request and set the query parameter
-        HttpServerRequest request = Mockito.mock(HttpServerRequest.class);
-        Mockito.when(request.response()).thenReturn(response);
-        Mockito.when(request.getParam("q")).thenReturn("destination");
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        HttpServerResponse response = mock(HttpServerResponse.class);
 
-        // Mock the route and listener
-        Route mockRoute = Mockito.mock(Route.class);
-        HttpHook mockHook = new HttpHook("destination/matching");
-        Mockito.when(mockRoute.getHook()).thenReturn(mockHook);
+        // Mock request and response behavior
+        when(request.uri()).thenReturn(uri);
+        when(request.method()).thenReturn(HttpMethod.GET);
+        when(request.getParam("q")).thenReturn(queryParam);
+        when(request.response()).thenReturn(response);
 
-        Listener mockListener = new Listener("listener1", "monitoredUrl", "destination/matching", mockHook);
+        // Mock RoutingContext
+        RoutingContext routingContext = mock(RoutingContext.class);
+        when(routingContext.request()).thenReturn(request);
 
-        // Mock repositories
-        ListenerRepository listenerRepository = Mockito.mock(ListenerRepository.class);
-        RouteRepository routeRepository = Mockito.mock(RouteRepository.class);
+        // Act
+        boolean result = hookHandler.handle(routingContext); // Calls the public `handle` method
 
-        // Configure mocked behavior for repositories
-        Mockito.when(routeRepository.getRoutes()).thenReturn(Map.of("route1", mockRoute));
-        Mockito.when(listenerRepository.getListeners()).thenReturn(Collections.singletonList(mockListener));
-
-        // Create HookHandler instance
-        HookHandler hookHandler = new HookHandler(vertx, httpClient, storage, loggingResourceManager,
-                logAppenderRepository, monitoringHandler, "userProfilePath", HOOK_ROOT_URI, requestQueue,
-                false
-        );
-
-        // Use reflection to set private fields
-        setPrivateField(hookHandler, "listenerRepository", listenerRepository);
-        setPrivateField(hookHandler, "routeRepository", routeRepository);
-
-        // Call the method under test
-        hookHandler.handleHookSearch("destination", response);
-
-        // Capture the output and verify the response was sent correctly
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        Mockito.verify(response).end(captor.capture());
-
-        // Check the result
-        String capturedResult = captor.getValue();
-        JsonObject result = new JsonObject(capturedResult);
-        JsonArray routes = result.getJsonArray("routes");
-        JsonArray listeners = result.getJsonArray("listeners");
-
-        // Assert the expected results
-        context.assertTrue(routes.contains("route1"));
-        context.assertTrue(listeners.contains("listener1"));
-
-        // Verify the content-type header was set correctly
-        Mockito.verify(response).putHeader("content-type", "application/json");
+        // Assert
+        assertTrue(result); // Ensure the handler returns true for a valid listener search
+        verify(response, times(1)).end(); // Ensure `response.end()` was called
     }
+    @Test
+    public void testHandleListenerSearch_MissingQueryParam() {
+        String uri = "registrations/listeners/?q=";
 
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        HttpServerResponse response = mock(HttpServerResponse.class);
 
-    private void setPrivateField(Object target, String fieldName, Object value) throws Exception {
-        Field field = target.getClass().getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(target, value);
+        when(request.uri()).thenReturn(uri);
+        when(request.method()).thenReturn(HttpMethod.GET);
+        when(request.getParam("q")).thenReturn("");
+        when(request.response()).thenReturn(response);
+
+        RoutingContext routingContext = mock(RoutingContext.class);
+        when(routingContext.request()).thenReturn(request);
+
+        boolean result = hookHandler.handle(routingContext);
+
+        assertFalse(result);
+        verify(response, never()).end();
     }
 
     @Test
-    public void testHookHandleSearchWithNoMatchingRoutesOrListeners(TestContext context) throws Exception {
-        // Mock the response
-        HttpServerResponse response = Mockito.mock(HttpServerResponse.class);
-        Mockito.when(response.putHeader(anyString(), anyString())).thenReturn(response);
+    public void testHandleListenerWithStorageAndSearchSuccess(TestContext context) {
+        vertx = Vertx.vertx();
+        storage = new MockResourceStorage();
+        LoggingResourceManager loggingResourceManager = Mockito.mock(LoggingResourceManager.class);
+        LogAppenderRepository logAppenderRepository = Mockito.mock(LogAppenderRepository.class);
+        MonitoringHandler monitoringHandler = Mockito.mock(MonitoringHandler.class);
+        RequestQueue requestQueue = Mockito.mock(RequestQueue.class);
 
-        // Mock the request and set the query parameter
+        hookHandler = new HookHandler(vertx, Mockito.mock(HttpClient.class), storage, loggingResourceManager, logAppenderRepository, monitoringHandler,
+                "userProfilePath", "hookRootURI/", requestQueue, false, null);
+        // Prepopulate storage with a listener resource
+        storage.putMockData("hookRootURI/registrations/listeners/listener1", "{ \"hook\": { \"destination\": \"/test/endpoint\" } }");
+
+        // Mock RoutingContext and its behavior
+        RoutingContext routingContext = Mockito.mock(RoutingContext.class);
         HttpServerRequest request = Mockito.mock(HttpServerRequest.class);
+        HttpServerResponse response = Mockito.mock(HttpServerResponse.class);
+
+        // Simulate a GET request with a query parameter
+        Mockito.when(request.method()).thenReturn(HttpMethod.GET);
+        Mockito.when(request.uri()).thenReturn("hookRootURI/registrations/listeners/?q=test");
+        Mockito.when(request.getParam("q")).thenReturn("test");
         Mockito.when(request.response()).thenReturn(response);
-        Mockito.when(request.getParam("q")).thenReturn("destination");
 
-        // Mock the route and listener
-        Route mockRoute = Mockito.mock(Route.class);
-        HttpHook mockHook = new HttpHook("destination/matching");
-        Mockito.when(mockRoute.getHook()).thenReturn(mockHook);
+        Mockito.when(routingContext.request()).thenReturn(request);
 
-        Listener mockListener = new Listener("listener1", "monitoredUrl", "destination/matching", mockHook);
+        // Async handler to check the result
+        Async async = context.async();
 
-        // Mock repositories
-        ListenerRepository listenerRepository = Mockito.mock(ListenerRepository.class);
-        RouteRepository routeRepository = Mockito.mock(RouteRepository.class);
+        // Act: Call the hookHandler.handle method
+        boolean handled = hookHandler.handle(routingContext);
 
-        // Configure mocked behavior for repositories with no matching routes or listeners
-        Mockito.when(routeRepository.getRoutes()).thenReturn(Map.of());
-        Mockito.when(listenerRepository.getListeners()).thenReturn(Collections.emptyList());
+        // Assert that it was handled
+        context.assertTrue(handled);
 
-        // Create HookHandler instance
-        HookHandler hookHandler = new HookHandler(vertx, httpClient, storage, loggingResourceManager,
-                logAppenderRepository, monitoringHandler, "userProfilePath", HOOK_ROOT_URI, requestQueue,
-                false
-        );
-
-        // Use reflection to set private fields
-        setPrivateField(hookHandler, "listenerRepository", listenerRepository);
-        setPrivateField(hookHandler, "routeRepository", routeRepository);
-
-        // Call the method under test
-        hookHandler.handleHookSearch("destination", response);
-
-        // Capture the output and verify the response was sent correctly
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        Mockito.verify(response).end(captor.capture());
-
-        // Check the result
-        String capturedResult = captor.getValue();
-        JsonObject result = new JsonObject(capturedResult);
-        JsonArray routes = result.getJsonArray("routes");
-        JsonArray listeners = result.getJsonArray("listeners");
-
-        // Assert that there are no matching routes or listeners
-        context.assertTrue(routes.isEmpty());
-        context.assertTrue(listeners.isEmpty());
-
-        // Verify the content-type header was set correctly
-        Mockito.verify(response).putHeader("content-type", "application/json");
+        // Verify that the response ended correctly (simulating a successful response)
+        Mockito.verify(response, Mockito.times(1)).end();
+        async.complete();
     }
 
     @Test
-    public void testHookHandleSearchWithInvalidQueryParam(TestContext context) {
-        // Mocking the HttpServerResponse and request objects
-        HttpServerResponse response = Mockito.mock(HttpServerResponse.class);
-        Mockito.when(response.putHeader(anyString(), anyString())).thenReturn(response);
+    public void testHandleListenerWithStorageAndSearchFailure(TestContext context) {
+        vertx = Vertx.vertx();
+        storage = new MockResourceStorage();
+        LoggingResourceManager loggingResourceManager = Mockito.mock(LoggingResourceManager.class);
+        LogAppenderRepository logAppenderRepository = Mockito.mock(LogAppenderRepository.class);
+        MonitoringHandler monitoringHandler = Mockito.mock(MonitoringHandler.class);
+        RequestQueue requestQueue = Mockito.mock(RequestQueue.class);
 
+        hookHandler = new HookHandler(vertx, Mockito.mock(HttpClient.class), storage, loggingResourceManager, logAppenderRepository, monitoringHandler,
+                "userProfilePath", "hookRootURI/", requestQueue, false, null);
+        RoutingContext routingContext = Mockito.mock(RoutingContext.class);
         HttpServerRequest request = Mockito.mock(HttpServerRequest.class);
+        HttpServerResponse response = Mockito.mock(HttpServerResponse.class);
+
+        // Simulate a GET request without a query parameter
+        Mockito.when(request.method()).thenReturn(HttpMethod.GET);
+        Mockito.when(request.uri()).thenReturn("hookRootURI/registrations/listeners/");
+        Mockito.when(request.getParam("q")).thenReturn(null); // No query parameter
         Mockito.when(request.response()).thenReturn(response);
-        Mockito.when(request.getParam("q")).thenReturn(null);
 
-        // Call hookHandleSearch
-        hookHandler.handleHookSearch(null, response);
+        Mockito.when(routingContext.request()).thenReturn(request);
 
-        // Verify that nothing is returned
-        Mockito.verify(response, Mockito.never()).end(any(Buffer.class));
+        // Async handler to check the result
+        Async async = context.async();
+
+        // Act: Call the hookHandler.handle method
+        boolean handled = hookHandler.handle(routingContext);
+
+        // Assert that it was NOT handled (as the query param is missing)
+        context.assertFalse(handled);
+
+        // Verify that the response was NOT ended (because it shouldn't be processed)
+        Mockito.verify(response, Mockito.never()).end();
+        async.complete();
     }
 
 
@@ -805,7 +791,7 @@ public class HookHandlerTest {
         };
         putRequest.addHeader(CONTENT_LENGTH.getName(), "99");
 
-        Mockito.when(routingContext.request()).thenReturn(putRequest);
+        when(routingContext.request()).thenReturn(putRequest);
         hookHandler.handle(routingContext);
 
         latch.await();

--- a/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
+++ b/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
@@ -669,27 +669,6 @@ public class HookHandlerTest {
         assertTrue(result); // Ensure the handler returns true for a valid listener search
         verify(response, times(1)).end(); // Ensure `response.end()` was called
     }
-    @Test
-    public void testHandleListenerSearch_MissingQueryParam() {
-        String uri = "registrations/listeners/?q=";
-
-        HttpServerRequest request = mock(HttpServerRequest.class);
-        HttpServerResponse response = mock(HttpServerResponse.class);
-
-        when(request.uri()).thenReturn(uri);
-        when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.getParam("q")).thenReturn("");
-        when(request.response()).thenReturn(response);
-        when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
-
-        RoutingContext routingContext = mock(RoutingContext.class);
-        when(routingContext.request()).thenReturn(request);
-
-        boolean result = hookHandler.handle(routingContext);
-
-        assertFalse(result);
-        verify(response, never()).end();
-    }
 
     @Test
     public void testHandleListenerWithStorageAndSearchSuccess(TestContext context) {
@@ -731,43 +710,6 @@ public class HookHandlerTest {
         Mockito.verify(response, Mockito.times(1)).end();
         async.complete();
     }
-
-    @Test
-    public void testHandleListenerWithStorageAndSearchFailure(TestContext context) {
-        vertx = Vertx.vertx();
-        storage = new MockResourceStorage();
-        LoggingResourceManager loggingResourceManager = Mockito.mock(LoggingResourceManager.class);
-        LogAppenderRepository logAppenderRepository = Mockito.mock(LogAppenderRepository.class);
-        MonitoringHandler monitoringHandler = Mockito.mock(MonitoringHandler.class);
-        RequestQueue requestQueue = Mockito.mock(RequestQueue.class);
-
-        hookHandler = new HookHandler(vertx, Mockito.mock(HttpClient.class), storage, loggingResourceManager, logAppenderRepository, monitoringHandler,
-                "userProfilePath", "hookRootURI/", requestQueue, false, null);
-        RoutingContext routingContext = Mockito.mock(RoutingContext.class);
-        HttpServerRequest request = Mockito.mock(HttpServerRequest.class);
-        HttpServerResponse response = Mockito.mock(HttpServerResponse.class);
-
-        // Mock necessary methods
-        Mockito.when(request.method()).thenReturn(HttpMethod.GET);
-        Mockito.when(request.uri()).thenReturn("hookRootURI/registrations/listeners/");
-        Mockito.when(request.getParam("q")).thenReturn(null); // No query param
-        Mockito.when(request.response()).thenReturn(response);
-        Mockito.when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
-
-
-        HttpClient selfClient = Mockito.mock(HttpClient.class);
-        Mockito.when(selfClient.request(Mockito.any(), Mockito.anyString())).thenReturn(Future.failedFuture(new Exception("Mocked failure")));
-
-        Mockito.when(routingContext.request()).thenReturn(request);
-
-        // Act
-        boolean handled = hookHandler.handle(routingContext);
-
-        // Assert
-        context.assertFalse(handled);
-        Mockito.verify(response, Mockito.never()).end();
-    }
-
 
     @Test
     public void testSearchMultipleListeners_Success(TestContext context) {

--- a/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
+++ b/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
@@ -703,7 +703,7 @@ public class HookHandlerTest {
 
         setListenerStorageEntryAndTriggerUpdate(buildListenerConfigWithHeadersFilter(null, singleListener, "x-foo: (A|B)"));
         // wait a moment to let the listener be registered
-        Thread.sleep(500);
+        Thread.sleep(200);
         // Mock RoutingContext and configure response capture
         when(routingContext.request()).thenReturn(request);
 
@@ -727,15 +727,18 @@ public class HookHandlerTest {
         String uri = "/hookRootURI/registrations/listeners";
         HttpServerResponse mockResponse = mock(HttpServerResponse.class);
         GETRequest request = new GETRequest(uri, mockResponse);
-        request.addParameter("q", "listener"); // Search parameter that should match multiple listeners
+        request.addParameter("q", "myListener"); // Search parameter that should match multiple listeners
 
         // Add multiple listeners to the MockResourceStorage using the expected configuration and register them
-        String listenerId1 = "listener112222";
-        String listenerId2 = "listener222133";
+        String listenerId1 = "myListener112222";
+        String listenerId2 = "myListener222133";
+        String notMatchListener = "notMatchListener";
         setListenerStorageEntryAndTriggerUpdate(buildListenerConfigWithHeadersFilter(null, listenerId1, "x-foo: (A|B)"));
-        Thread.sleep(500);
+        Thread.sleep(200);
         setListenerStorageEntryAndTriggerUpdate(buildListenerConfigWithHeadersFilter(null, listenerId2, "x-foo: (A|B)"));
-        Thread.sleep(500);
+        Thread.sleep(200);
+        setListenerStorageEntryAndTriggerUpdate(buildListenerConfigWithHeadersFilter(null, notMatchListener, "x-foo: (A|B)"));
+        Thread.sleep(200);
 
         // Mock the RoutingContext and set up the response capture
         when(routingContext.request()).thenReturn(request);
@@ -752,6 +755,7 @@ public class HookHandlerTest {
         assertNotNull(jsonResponse);
         assertTrue(jsonResponse.contains(listenerId1));
         assertTrue(jsonResponse.contains(listenerId2));
+        assertFalse(jsonResponse.contains(notMatchListener));
     }
 
 
@@ -790,15 +794,18 @@ public class HookHandlerTest {
         String uri = "/hookRootURI/registrations/routes";
         HttpServerResponse mockResponse = mock(HttpServerResponse.class);
         GETRequest request = new GETRequest(uri, mockResponse);
-        request.addParameter("q", "route"); // Search parameter that should match multiple routes
+        request.addParameter("q", "valid"); // Search parameter that should match multiple routes
 
         // Add multiple routes to the MockResourceStorage using the expected configuration and register them
-        String routeId1 = "route12345";
-        String routeId2 = "route67890";
+        String routeId1 = "valid12345";
+        String routeId2 = "valid67890";
+        String notPreset = "notPreset";
         setRouteStorageEntryAndTriggerUpdate(buildRouteConfig(routeId1));
-        Thread.sleep(500);
+        Thread.sleep(200);
         setRouteStorageEntryAndTriggerUpdate(buildRouteConfig( routeId2));
-        Thread.sleep(500);
+        Thread.sleep(200);
+        setRouteStorageEntryAndTriggerUpdate(buildRouteConfig( notPreset));
+        Thread.sleep(200);
 
         // Mock the RoutingContext and set up the response capture
         when(routingContext.request()).thenReturn(request);
@@ -815,6 +822,7 @@ public class HookHandlerTest {
         assertNotNull(jsonResponse);
         assertTrue(jsonResponse.contains(routeId1));
         assertTrue(jsonResponse.contains(routeId2));
+        assertFalse(jsonResponse.contains(notPreset));
     }
 
     @Test
@@ -1240,10 +1248,6 @@ public class HookHandlerTest {
         @Override
         public String getParam(String paramName) {
             return params.get(paramName);
-        }
-
-        public void addHeader(String headerName, String headerValue) {
-            headers.add(headerName, headerValue);
         }
 
         public void addParameter(String paramName, String paramValue) {

--- a/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
+++ b/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
@@ -680,6 +680,7 @@ public class HookHandlerTest {
         when(request.method()).thenReturn(HttpMethod.GET);
         when(request.getParam("q")).thenReturn("");
         when(request.response()).thenReturn(response);
+        when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         RoutingContext routingContext = mock(RoutingContext.class);
         when(routingContext.request()).thenReturn(request);
@@ -746,27 +747,27 @@ public class HookHandlerTest {
         HttpServerRequest request = Mockito.mock(HttpServerRequest.class);
         HttpServerResponse response = Mockito.mock(HttpServerResponse.class);
 
-        // Simulate a GET request without a query parameter
+        // Mock necessary methods
         Mockito.when(request.method()).thenReturn(HttpMethod.GET);
         Mockito.when(request.uri()).thenReturn("hookRootURI/registrations/listeners/");
-        Mockito.when(request.getParam("q")).thenReturn(null); // No query parameter
+        Mockito.when(request.getParam("q")).thenReturn(null); // No query param
         Mockito.when(request.response()).thenReturn(response);
+        Mockito.when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+
+
+        HttpClient selfClient = Mockito.mock(HttpClient.class);
+        Mockito.when(selfClient.request(Mockito.any(), Mockito.anyString())).thenReturn(Future.failedFuture(new Exception("Mocked failure")));
 
         Mockito.when(routingContext.request()).thenReturn(request);
 
-        // Async handler to check the result
-        Async async = context.async();
-
-        // Act: Call the hookHandler.handle method
+        // Act
         boolean handled = hookHandler.handle(routingContext);
 
-        // Assert that it was NOT handled (as the query param is missing)
+        // Assert
         context.assertFalse(handled);
-
-        // Verify that the response was NOT ended (because it shouldn't be processed)
         Mockito.verify(response, Mockito.never()).end();
-        async.complete();
     }
+
 
     @Test
     public void testSearchMultipleListeners_Success(TestContext context) {

--- a/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
+++ b/gateleen-hook/src/test/java/org/swisspush/gateleen/hook/HookHandlerTest.java
@@ -688,7 +688,7 @@ public class HookHandlerTest {
         String jsonResponse = responseCaptor.getValue();
         testContext.assertNotNull(jsonResponse);
         // Confirm the response contains "Bad Request"
-        testContext.assertTrue(jsonResponse.contains("Bad Request"));
+        testContext.assertTrue(jsonResponse.contains("Only the 'q' parameter is allowed and can't be empty or null"));
     }
 
     @Test
@@ -719,7 +719,6 @@ public class HookHandlerTest {
         String singleListener= "mySingleListener";
         GETRequest request = new GETRequest(HOOK_LISTENER_URI, mockResponse);
         request.addParameter("q", singleListener);
-
 
         setListenerStorageEntryAndTriggerUpdate(buildListenerConfigWithHeadersFilter(null, singleListener, "x-foo: (A|B)"));
         // wait a moment to let the listener be registered
@@ -775,7 +774,6 @@ public class HookHandlerTest {
         assertTrue(jsonResponse.contains(listenerId2));
         assertFalse(jsonResponse.contains(notMatchListener));
     }
-
 
     @Test
     public void testHandleGETRequestWithRoutesSearchEmptyResult() {
@@ -861,7 +859,6 @@ public class HookHandlerTest {
         // Validate the response JSON for an empty listener list
         String actualResponse = responseCaptor.getValue();
         assertEmptyResult(actualResponse);
-
     }
 
     @Test
@@ -890,13 +887,13 @@ public class HookHandlerTest {
         String jsonResponse = responseCaptor.getValue();
         testContext.assertNotNull(jsonResponse);
         // Confirm that the response contains "Bad Request"
-        testContext.assertTrue(jsonResponse.contains("Bad Request"));
+        testContext.assertTrue(jsonResponse.contains("Only the 'q' parameter is allowed and can't be empty or null"));
     }
 
     @Test
     public void testHandleGETRequestWithTrailingSlash(TestContext testContext) {
         // Define URI with trailing slash and configure the request
-        GETRequest request = new GETRequest(HOOK_LISTENER_URI+"/", mockResponse);
+        GETRequest request = new GETRequest(HOOK_LISTENER_URI + "/", mockResponse);
         request.addParameter("q", "validQueryParam");
 
         // Mock the RoutingContext
@@ -940,7 +937,7 @@ public class HookHandlerTest {
         String jsonResponse = responseCaptor.getValue();
         testContext.assertNotNull(jsonResponse);
         // Confirm that the response contains "Bad Request"
-        testContext.assertTrue(jsonResponse.contains("Bad Request"));
+        testContext.assertTrue(jsonResponse.contains("Only the 'q' parameter is allowed and can't be empty or null"));
     }
 
 

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
@@ -995,13 +995,45 @@ public class ListenerTest extends AbstractTest {
         // Send GET request with non-matching query param
         given().queryParam("q", nonMatchingQueryParam)
                 .when().get(requestUrl)
-                .then().assertThat().statusCode(404); // Expecting 404 as no listener matches the query
+                .then().assertThat()
+                .statusCode(200) // Expecting 200 as the request is valid but no match found
+                .body("listeners", org.hamcrest.Matchers.empty()); // Expecting an empty list of listeners
 
-        // Validate that the response is not found
-        checkGETStatusCodeWithAwait(requestUrl, 404);
+        // Validate that the response is 200 and the result is an empty array
+        checkGETStatusCodeWithAwait(requestUrl, 200);
 
         // Unregister the listener
         TestUtils.unregisterListener(requestUrlBase + listenerPath);
+
+        async.complete();
+    }
+
+    /**
+     * Test for hookHandleSearch with listener storage path and valid query param but no listeners registered. <br />
+     * eg. register / unregister: http://localhost:7012/gateleen/server/listenertest/_hooks/listeners/listener/1 <br />
+     * requestUrl: http://localhost:7012/gateleen/server/listenertest/listener/test?q=someQuery
+     */
+    @Test
+    public void testHookHandleSearch_NoListenersRegistered(TestContext context) {
+        Async async = context.async();
+        delete();
+        initRoutingRules();
+
+        String queryParam = "someQuery";
+        String listenerPath = "/_hooks/listeners";
+        String requestUrl = requestUrlBase + listenerPath + "?q=" + queryParam;
+
+        // No listeners registered
+
+        // Send GET request with a query param
+        given().queryParam("q", queryParam)
+                .when().get(requestUrl)
+                .then().assertThat()
+                .statusCode(200) // Expecting 200 as the request is valid but no listeners are registered
+                .body("listeners", org.hamcrest.Matchers.empty()); // Expecting an empty list of listeners
+
+        // Validate that the response is 200 and the result is an empty array
+        checkGETStatusCodeWithAwait(requestUrl, 200);
 
         async.complete();
     }

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
@@ -68,8 +68,6 @@ public class ListenerTest extends AbstractTest {
         defaultRegisterUrlListener = requestUrlBase + "/" + defaultQueryParam + TestUtils.getHookListenersUrlSuffix() + defaultListenerName;
         defaultTargetListener = targetUrlBase + "/" + defaultListenerName;
         defaultMethodsListener = new String[]{"PUT", "DELETE", "POST"};
-
-
     }
 
     /**
@@ -1172,7 +1170,7 @@ public class ListenerTest extends AbstractTest {
     private Response searchWithQueryParam(String searchParam, String queryParam, int expectedStatusCode ) {
         return given()
                 .queryParam(searchParam, queryParam)
-                .when().get(searchUrlBase )
+                .when().get(searchUrlBase)
                 .then().assertThat().statusCode(expectedStatusCode)
                 .extract().response();
     }

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
@@ -888,92 +888,6 @@ public class ListenerTest extends AbstractTest {
         async.complete();
     }
 
-    /**
-     * Checks if the DELETE request gets a response
-     * with the given status code.
-     *
-     * @param requestUrl
-     * @param statusCode
-     */
-    private void checkDELETEStatusCode(String requestUrl, int statusCode) {
-        delete(requestUrl).then().assertThat().statusCode(statusCode);
-    }
-
-    /**
-     * Checks if the DELETE request gets a response
-     * with the given status code.
-     *
-     * @param requestUrl
-     * @param statusCode
-     * @param headers
-     */
-    private void checkDELETEStatusCode(String requestUrl, int statusCode, Headers headers) {
-        with().headers(headers).delete(requestUrl).then().assertThat().statusCode(statusCode);
-    }
-
-    /**
-     * Checks if the PUT request gets a response
-     * with the given status code.
-     *
-     * @param requestUrl
-     * @param body
-     * @param statusCode
-     */
-    private void checkPUTStatusCode(String requestUrl, String body, int statusCode) {
-        with().body(body).put(requestUrl).then().assertThat().statusCode(statusCode);
-    }
-
-    /**
-     * Checks if the PUT request gets a response
-     * with the given status code.
-     *
-     * @param requestUrl
-     * @param body
-     * @param statusCode
-     * @param headers
-     */
-    private void checkPUTStatusCode(String requestUrl, String body, int statusCode, Headers headers) {
-        with().headers(headers).body(body).put(requestUrl).then().assertThat().statusCode(statusCode);
-    }
-
-    /**
-     * Checks if the GET request for the
-     * resource gets a response with
-     * the given status code.
-     *
-     * @param request
-     * @param statusCode
-     */
-    private void checkGETStatusCodeWithAwait(final String request, final Integer statusCode) {
-        await().atMost(FIVE_SECONDS).until(() -> String.valueOf(when().get(request).getStatusCode()), equalTo(String.valueOf(statusCode)));
-    }
-
-    /**
-     * Checks if the GET request of the
-     * given resource returns the wished body.
-     *
-     * @param requestUrl
-     * @param body
-     */
-    private void checkGETBodyWithAwait(final String requestUrl, final String body) {
-        await().atMost(TEN_SECONDS).until(() -> when().get(requestUrl).then().extract().body().asString(), equalTo(body));
-    }
-
-    private Response searchWithQueryParam(String searchParam, String queryParam, int expectedStatusCode ) {
-        return given()
-                .queryParam(searchParam, queryParam)
-                .when().get(searchUrlBase )
-                .then().assertThat().statusCode(expectedStatusCode)
-                .extract().response();
-    }
-    private void registerDefaultListener() {
-        delete();
-        initRoutingRules();
-        delete(searchUrlBase);
-        delete(defaultTargetListener);
-        TestUtils.registerListener(defaultRegisterUrlListener, defaultTargetListener, defaultMethodsListener, null, null,
-                null, null, "x-foo: (A|B)");
-    }
     @Test
     public void testSearchListenerWithValidAndInvalidSearchParam(TestContext context) {
         Async async = context.async();
@@ -984,7 +898,7 @@ public class ListenerTest extends AbstractTest {
 
         Response response = searchWithQueryParam("q",defaultListenerName,200);
 
-        Assert.assertTrue(response.getBody().asString().contains(defaultListenerName)); // Fails if not found
+        Assert.assertTrue(response.getBody().asString().contains(defaultListenerName));
         TestUtils.unregisterListener(defaultRegisterUrlListener);
 
         async.complete();
@@ -1023,7 +937,6 @@ public class ListenerTest extends AbstractTest {
         // Parse response body as JSON
         JsonObject jsonResponse = new JsonObject(response.getBody().asString());
 
-        // Assert that the response contains the expected query param
         Assert.assertTrue("Expected 'listeners' to be an empty array",
                 jsonResponse.containsKey("listeners") && jsonResponse.getJsonArray("listeners").isEmpty());
         async.complete();
@@ -1066,13 +979,13 @@ public class ListenerTest extends AbstractTest {
         registerDefaultListener();
 
         Response response = given()
-                    .queryParam("q", defaultListenerName)
-                    .when().get(searchUrlBase +"/")
-                    .then().assertThat().statusCode(200)
-                    .extract().response();
+                .queryParam("q", defaultListenerName)
+                .when().get(searchUrlBase +"/")
+                .then().assertThat().statusCode(200)
+                .extract().response();
 
         // Assert that the response contains the expected query param
-        Assert.assertTrue(response.getBody().asString().contains(defaultListenerName)); // Fails if not found
+        Assert.assertTrue(response.getBody().asString().contains(defaultListenerName));
 
         TestUtils.unregisterListener(defaultRegisterUrlListener);
 
@@ -1088,8 +1001,7 @@ public class ListenerTest extends AbstractTest {
 
         Response response = searchWithQueryParam("q","",400);
 
-        // Assert that the response contains the expected query param
-        Assert.assertTrue(response.getBody().asString().contains("Bad Request")); // Fails if not found
+        Assert.assertTrue(response.getBody().asString().contains("Bad Request"));
         TestUtils.unregisterListener(defaultRegisterUrlListener);
 
         async.complete();
@@ -1184,5 +1096,90 @@ public class ListenerTest extends AbstractTest {
         // Clean up by removing the registered listener after the test
         TestUtils.unregisterListener(defaultRegisterUrlListener);
         async.complete();
+    }
+
+    /**
+     * Checks if the DELETE request gets a response
+     * with the given status code.
+     *
+     * @param requestUrl
+     * @param statusCode
+     */
+    private void checkDELETEStatusCode(String requestUrl, int statusCode) {
+        delete(requestUrl).then().assertThat().statusCode(statusCode);
+    }
+
+    /**
+     * Checks if the DELETE request gets a response
+     * with the given status code.
+     *
+     * @param requestUrl
+     * @param statusCode
+     * @param headers
+     */
+    private void checkDELETEStatusCode(String requestUrl, int statusCode, Headers headers) {
+        with().headers(headers).delete(requestUrl).then().assertThat().statusCode(statusCode);
+    }
+
+    /**
+     * Checks if the PUT request gets a response
+     * with the given status code.
+     *
+     * @param requestUrl
+     * @param body
+     * @param statusCode
+     */
+    private void checkPUTStatusCode(String requestUrl, String body, int statusCode) {
+        with().body(body).put(requestUrl).then().assertThat().statusCode(statusCode);
+    }
+
+    /**
+     * Checks if the PUT request gets a response
+     * with the given status code.
+     *
+     * @param requestUrl
+     * @param body
+     * @param statusCode
+     * @param headers
+     */
+    private void checkPUTStatusCode(String requestUrl, String body, int statusCode, Headers headers) {
+        with().headers(headers).body(body).put(requestUrl).then().assertThat().statusCode(statusCode);
+    }
+
+    /**
+     * Checks if the GET request for the
+     * resource gets a response with
+     * the given status code.
+     *
+     * @param request
+     * @param statusCode
+     */
+    private void checkGETStatusCodeWithAwait(final String request, final Integer statusCode) {
+        await().atMost(FIVE_SECONDS).until(() -> String.valueOf(when().get(request).getStatusCode()), equalTo(String.valueOf(statusCode)));
+    }
+
+    /**
+     * Checks if the GET request of the
+     * given resource returns the wished body.
+     *
+     * @param requestUrl
+     * @param body
+     */
+    private void checkGETBodyWithAwait(final String requestUrl, final String body) {
+        await().atMost(TEN_SECONDS).until(() -> when().get(requestUrl).then().extract().body().asString(), equalTo(body));
+    }
+
+    private Response searchWithQueryParam(String searchParam, String queryParam, int expectedStatusCode ) {
+        return given()
+                .queryParam(searchParam, queryParam)
+                .when().get(searchUrlBase )
+                .then().assertThat().statusCode(expectedStatusCode)
+                .extract().response();
+    }
+    private void registerDefaultListener() {
+        delete();
+        initRoutingRules();
+        TestUtils.registerListener(defaultRegisterUrlListener, defaultTargetListener, defaultMethodsListener, null, null,
+                null, null, "x-foo: (A|B)");
     }
 }

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
@@ -945,8 +945,7 @@ public class ListenerTest extends AbstractTest {
 
     /**
      * Test for hookHandleSearch with listener storage path and valid query param. <br />
-     * eg. register / unregister: http://localhost:7012/gateleen/server/listenertest/_hooks/listeners/listener/1 <br />
-     * requestUrl: http://localhost:7012/gateleen/server/listenertest/listener/test?q=testQuery
+     * requestUrl: http://localhost:7012/playground/server/hooks/v1/registrations/listeners/?q=testQuery
      */
     @Test
     public void testHookHandleSearch_ListenerPathWithValidQueryParam(TestContext context) {
@@ -976,8 +975,7 @@ public class ListenerTest extends AbstractTest {
 
     /**
      * Test for hookHandleSearch with listener storage path and valid query param but no match found. <br />
-     * eg. register / unregister: http://localhost:7012/gateleen/server/listenertest/_hooks/listeners/listener/1 <br />
-     * requestUrl: http://localhost:7012/gateleen/server/listenertest/listener/test?q=nonMatchingQuery
+     * requestUrl: http://localhost:7012/playground/server/hooks/v1/registrations/listeners/?q=nonMatchingQuery
      */
     @Test
     public void testHookHandleSearch_ListenerPathWithNonMatchingQueryParam(TestContext context) {
@@ -1011,8 +1009,7 @@ public class ListenerTest extends AbstractTest {
 
     /**
      * Test for hookHandleSearch with listener storage path and valid query param but no listeners registered. <br />
-     * eg. register / unregister: http://localhost:7012/gateleen/server/listenertest/_hooks/listeners/listener/1 <br />
-     * requestUrl: http://localhost:7012/gateleen/server/listenertest/listener/test?q=someQuery
+     * requestUrl: http://localhost:7012/playground/server/hooks/v1/registrations/listeners/?q=someQuery
      */
     @Test
     public void testHookHandleSearch_NoListenersRegistered(TestContext context) {
@@ -1035,6 +1032,63 @@ public class ListenerTest extends AbstractTest {
 
         // Validate that the response is 200 and the result is an empty array
         checkGETStatusCodeWithAwait(requestUrl, 200);
+
+        async.complete();
+    }
+
+
+    @Test
+    public void testHookHandleSearch_ListenerPathInvalidParam(TestContext context) {
+        Async async = context.async();
+        delete();
+        initRoutingRules();
+
+        String queryParam = "testQuery";
+        String listenerPath = "/_hooks/listeners";
+        String requestUrl = requestUrlBase + listenerPath + "?www=" + queryParam;
+
+        // Register a listener
+        TestUtils.registerListener(requestUrlBase + listenerPath, targetUrlBase, new String[]{"GET", "POST"}, null);
+
+        // Send GET request
+        given().queryParam("www", queryParam)
+                .when().get(requestUrl)
+                .then().assertThat().statusCode(400);
+
+        // Validate the response
+        checkGETStatusCodeWithAwait(requestUrl, 400);
+
+        TestUtils.unregisterListener(requestUrlBase + listenerPath);
+
+        async.complete();
+    }
+
+    /**
+     * Test for hookHandleSearch with listener storage path and no query parameter. <br />
+     * requestUrl: http://localhost:7012/playground/server/hooks/v1/registrations/listeners/?q=
+     */
+    @Test
+    public void testHookHandleSearch_NoQueryParameter(TestContext context) {
+        Async async = context.async();
+        delete();
+        initRoutingRules();
+
+        String queryParam = "";
+        String listenerPath = "/_hooks/listeners";
+        String requestUrl = requestUrlBase + listenerPath + "?q=" + queryParam;
+
+        // Register a listener
+        TestUtils.registerListener(requestUrlBase + listenerPath, targetUrlBase, new String[]{"GET", "POST"}, null);
+
+        // Send GET request
+        given().queryParam("q", queryParam)
+                .when().get(requestUrl)
+                .then().assertThat().statusCode(400);
+
+        // Validate the response
+        checkGETStatusCodeWithAwait(requestUrl, 400);
+
+        TestUtils.unregisterListener(requestUrlBase + listenerPath);
 
         async.complete();
     }

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
@@ -43,6 +43,7 @@ public class ListenerTest extends AbstractTest {
     private final static int WIREMOCK_PORT = 8881;
     private String requestUrlBase;
     private String targetUrlBase;
+    private String searchUrlBase;
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(WIREMOCK_PORT);
@@ -56,6 +57,8 @@ public class ListenerTest extends AbstractTest {
 
         requestUrlBase = "/tests/gateleen/monitoredresource";
         targetUrlBase = "http://localhost:" + MAIN_PORT + SERVER_ROOT + "/tests/gateleen/targetresource";
+        searchUrlBase = "http://localhost:" + MAIN_PORT + SERVER_ROOT + "/hooks/v1/registrations/listeners";
+
     }
 
     /**
@@ -956,17 +959,16 @@ public class ListenerTest extends AbstractTest {
         initRoutingRules();
 
         // Settings
-        String subresource = "validQueryParameter";
+        String subresource = "matchingQueryParam";
         String listenerName = "myListener";
 
-        String registerUrlListener1 = requestUrlBase + "/" + subresource + TestUtils.getHookListenersUrlSuffix() + listenerName;
+        String registerUrlListener1 = requestUrlBase + "/" + subresource  + TestUtils.getHookListenersUrlSuffix() + listenerName;
         String targetListener1 = targetUrlBase + "/" + listenerName;
         String[] methodsListener1 = new String[]{"PUT", "DELETE", "POST"};
         final String targetUrlListener1 = targetUrlBase + "/" + listenerName;
 
-        final String requestUrl = requestUrlBase + "/" + subresource;
 
-        delete(requestUrl);
+        delete(searchUrlBase);
         delete(targetUrlListener1);
 
         //Sending request, one listener hooked
@@ -976,11 +978,12 @@ public class ListenerTest extends AbstractTest {
         // Verify that the listener was correctly registered
         Response response = given()
                 .queryParam("q", listenerName)
-                .when().get(registerUrlListener1)
+                .when().get(searchUrlBase)
                 .then().assertThat().statusCode(200)
                 .extract().response();
 
         // Assert that the response contains the expected query param
+        System.out.println(response.getBody().asString());
         Assert.assertTrue(response.getBody().asString().contains(listenerName)); // Fails if not found
         TestUtils.unregisterListener(registerUrlListener1);
 
@@ -1006,9 +1009,8 @@ public class ListenerTest extends AbstractTest {
         String[] methodsListener1 = new String[]{"PUT", "DELETE", "POST"};
         final String targetUrlListener1 = targetUrlBase + "/" + listenerName + "/" + "test";
 
-        final String requestUrl = requestUrlBase + "/" + subresource + "/" + "test";
 
-        delete(requestUrl);
+        delete(searchUrlBase);
         delete(targetUrlListener1);
 
         TestUtils.registerListener(registerUrlListener1, targetListener1, methodsListener1, null, null,
@@ -1017,7 +1019,7 @@ public class ListenerTest extends AbstractTest {
         // Verify that the listener was correctly registered
         Response response = given()
                 .queryParam("q", listenerName)
-                .when().get(registerUrlListener1)
+                .when().get(searchUrlBase)
                 .then().assertThat().statusCode(200)
                 .extract().response();
 
@@ -1028,7 +1030,7 @@ public class ListenerTest extends AbstractTest {
         // Verify that the listener search with a no registered listener
         response = given()
                 .queryParam("q", listenerName)
-                .when().get(registerUrlListener1)
+                .when().get(searchUrlBase)
                 .then().assertThat().statusCode(200)
                 .extract().response();
 
@@ -1050,13 +1052,12 @@ public class ListenerTest extends AbstractTest {
         initRoutingRules();
 
         String queryParam = "someQuery";
-        String listenerPath = "/_hooks/listeners";
-        String requestUrl = requestUrlBase + listenerPath;
+        String listenerPath = "/hooks/listeners";
 
         // Verify that the listener search with a no registered listener
         Response response = given()
                 .queryParam("q", queryParam)
-                .when().get(requestUrl)
+                .when().get(searchUrlBase)
                 .then().assertThat().statusCode(200)
                 .extract().response();
 
@@ -1074,7 +1075,7 @@ public class ListenerTest extends AbstractTest {
 
         String queryParam = "testQuery";
         String listenerPath = "/_hooks/listeners";
-        String requestUrl = requestUrlBase + listenerPath + "?www=" + queryParam;
+        String requestUrl = searchUrlBase+ "?www=" + queryParam;
 
         // Validate the response
         checkGETStatusCodeWithAwait(requestUrl, 400);
@@ -1100,9 +1101,7 @@ public class ListenerTest extends AbstractTest {
         String[] methodsListener1 = new String[]{"PUT", "DELETE", "POST"};
         final String targetUrlListener1 = targetUrlBase + "/" + listenerName;
 
-        final String requestUrl = requestUrlBase + "/" + subresource;
-
-        delete(requestUrl);
+        delete(searchUrlBase);
         delete(targetUrlListener1);
 
         //Sending request, one listener hooked
@@ -1112,7 +1111,7 @@ public class ListenerTest extends AbstractTest {
         // Verify that the listener was correctly registered
         Response response = given()
                 .queryParam("q", listenerName)
-                .when().get(registerUrlListener1)
+                .when().get(searchUrlBase)
                 .then().assertThat().statusCode(400)
                 .extract().response();
 
@@ -1159,7 +1158,7 @@ public class ListenerTest extends AbstractTest {
         // Perform a search for the listeners that should return only listenerOne and listenerTwo
         Response response = given()
                 .queryParam("q", "listener")
-                .when().get(requestUrlBase + "/" + subresource + TestUtils.getHookListenersUrlSuffix())
+                .when().get(searchUrlBase)
                 .then().assertThat().statusCode(200)
                 .extract().response();
 

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
@@ -47,7 +47,6 @@ public class ListenerTest extends AbstractTest {
     private String defaultRegisterUrlListener;
     private String defaultTargetListener;
     private String[] defaultMethodsListener;
-    private final String defaultQueryParam = "defaultQueryParam";
     private final String defaultListenerName = "defaultListener";
 
     @Rule
@@ -65,7 +64,8 @@ public class ListenerTest extends AbstractTest {
         targetUrlBase = "http://localhost:" + MAIN_PORT + SERVER_ROOT + "/tests/gateleen/targetresource";
         searchUrlBase = "http://localhost:" + MAIN_PORT + SERVER_ROOT + "/hooks/v1/registrations/listeners";
 
-        defaultRegisterUrlListener = requestUrlBase + "/" + defaultQueryParam  + TestUtils.getHookListenersUrlSuffix() + defaultListenerName;
+        String defaultQueryParam = "defaultQueryParam";
+        defaultRegisterUrlListener = requestUrlBase + "/" + defaultQueryParam + TestUtils.getHookListenersUrlSuffix() + defaultListenerName;
         defaultTargetListener = targetUrlBase + "/" + defaultListenerName;
         defaultMethodsListener = new String[]{"PUT", "DELETE", "POST"};
 
@@ -1050,7 +1050,7 @@ public class ListenerTest extends AbstractTest {
         initRoutingRules();
 
         String queryParam = "testQuery";
-        String requestUrl = searchUrlBase+ "?q=" + queryParam+"&www=" + queryParam;;
+        String requestUrl = searchUrlBase+ "?q=" + queryParam+"&www=" + queryParam;
 
         // Validate the response
         checkGETStatusCodeWithAwait(requestUrl, 400);

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
@@ -942,4 +942,35 @@ public class ListenerTest extends AbstractTest {
     private void checkGETBodyWithAwait(final String requestUrl, final String body) {
         await().atMost(TEN_SECONDS).until(() -> when().get(requestUrl).then().extract().body().asString(), equalTo(body));
     }
+    /**
+     * Test for hookHandleSearch with listener storage path and valid query param. <br />
+     * eg. register / unregister: http://localhost:7012/gateleen/server/listenertest/_hooks/listeners/listener/1 <br />
+     * requestUrl: http://localhost:7012/gateleen/server/listenertest/listener/test?q=testQuery
+     */
+    @Test
+    public void testHookHandleSearch_ListenerPathWithValidQueryParam(TestContext context) {
+        Async async = context.async();
+        delete();
+        initRoutingRules();
+
+        String queryParam = "testQuery";
+        String listenerPath = "/_hooks/listeners";
+        String requestUrl = requestUrlBase + listenerPath + "?q=" + queryParam;
+
+        // Register a listener
+        TestUtils.registerListener(requestUrlBase + listenerPath, targetUrlBase, new String[]{"GET", "POST"}, null);
+
+        // Send GET request
+        given().queryParam("q", queryParam)
+                .when().get(requestUrl)
+                .then().assertThat().statusCode(200);
+
+        // Validate the response
+        checkGETStatusCodeWithAwait(requestUrl, 200);
+
+        TestUtils.unregisterListener(requestUrlBase + listenerPath);
+
+        async.complete();
+    }
+
 }

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
@@ -999,7 +999,7 @@ public class ListenerTest extends AbstractTest {
 
         Response response = searchWithQueryParam("q","",400);
 
-        Assert.assertTrue(response.getBody().asString().contains("Bad Request"));
+        Assert.assertTrue(response.getBody().asString().contains("Only the 'q' parameter is allowed and can't be empty or null"));
         TestUtils.unregisterListener(defaultRegisterUrlListener);
 
         async.complete();

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
@@ -942,6 +942,7 @@ public class ListenerTest extends AbstractTest {
     private void checkGETBodyWithAwait(final String requestUrl, final String body) {
         await().atMost(TEN_SECONDS).until(() -> when().get(requestUrl).then().extract().body().asString(), equalTo(body));
     }
+
     /**
      * Test for hookHandleSearch with listener storage path and valid query param. <br />
      * eg. register / unregister: http://localhost:7012/gateleen/server/listenertest/_hooks/listeners/listener/1 <br />

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/ListenerTest.java
@@ -973,4 +973,37 @@ public class ListenerTest extends AbstractTest {
         async.complete();
     }
 
+    /**
+     * Test for hookHandleSearch with listener storage path and valid query param but no match found. <br />
+     * eg. register / unregister: http://localhost:7012/gateleen/server/listenertest/_hooks/listeners/listener/1 <br />
+     * requestUrl: http://localhost:7012/gateleen/server/listenertest/listener/test?q=nonMatchingQuery
+     */
+    @Test
+    public void testHookHandleSearch_ListenerPathWithNonMatchingQueryParam(TestContext context) {
+        Async async = context.async();
+        delete();
+        initRoutingRules();
+
+        String nonMatchingQueryParam = "nonMatchingQuery";
+        String listenerPath = "/_hooks/listeners";
+        String requestUrl = requestUrlBase + listenerPath + "?q=" + nonMatchingQueryParam;
+
+        // Register a listener with a different query param
+        String differentQueryParam = "differentQuery";
+        TestUtils.registerListener(requestUrlBase + listenerPath + "?q=" + differentQueryParam, targetUrlBase, new String[]{"GET", "POST"}, null);
+
+        // Send GET request with non-matching query param
+        given().queryParam("q", nonMatchingQueryParam)
+                .when().get(requestUrl)
+                .then().assertThat().statusCode(404); // Expecting 404 as no listener matches the query
+
+        // Validate that the response is not found
+        checkGETStatusCodeWithAwait(requestUrl, 404);
+
+        // Unregister the listener
+        TestUtils.unregisterListener(requestUrlBase + listenerPath);
+
+        async.complete();
+    }
+
 }

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/RouteListingTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/RouteListingTest.java
@@ -27,7 +27,7 @@ public class RouteListingTest extends AbstractTest {
     private String requestUrlBase;
     private String targetUrlBase;
     private String parentKey;
-
+    private String searchUrlBase;
 
     /**
      * Overwrite RestAssured configuration
@@ -39,6 +39,7 @@ public class RouteListingTest extends AbstractTest {
         parentKey = "routesource";
         requestUrlBase = "/tests/gateleen/" + parentKey;
         targetUrlBase = "http://localhost:" + MAIN_PORT + SERVER_ROOT + "/tests/gateleen/routetarget";
+        searchUrlBase = "http://localhost:" + MAIN_PORT + SERVER_ROOT + "/hooks/v1/registrations/routes";
     }
 
 
@@ -236,14 +237,14 @@ public class RouteListingTest extends AbstractTest {
 
         String queryParam = "routeTests";
         String routePath = "/routes";
-        String requestUrl = requestUrlBase + routePath;
+
 
         addRoute(queryParam, true, true);
 
         // Verify that the route was correctly registered
         Response response = given()
                 .queryParam("q", queryParam)
-                .when().get(requestUrl )
+                .when().get(searchUrlBase )
                 .then().assertThat().statusCode(200)
                 .extract().response();
 
@@ -268,16 +269,23 @@ public class RouteListingTest extends AbstractTest {
 
         String nonMatchingQueryParam = "nonMatchingQuery";
         String queryParam = "other";
-        String routePath = "/routes";
-        String requestUrl = requestUrlBase + routePath;
 
         // Register a route using the addRoute method
         addRoute(queryParam, true, true);
         assertResponse(get(requestUrlBase), new String[]{queryParam+"/"});
 
         // Send GET request with a non-matching query param
-        Response response = given().queryParam("q", nonMatchingQueryParam)
-                .when().get(requestUrl)
+        Response response = given().queryParam("q", queryParam)
+                .when().get(searchUrlBase)
+                .then().assertThat().statusCode(200)
+                .extract().response();
+
+        Assert.assertTrue("Query param should be found in response",
+                response.getBody().asString().contains(queryParam));
+
+        // Send GET request with a non-matching query param
+         response = given().queryParam("q", nonMatchingQueryParam)
+                .when().get(searchUrlBase)
                 .then().assertThat().statusCode(200)
                 .extract().response();
 
@@ -287,7 +295,7 @@ public class RouteListingTest extends AbstractTest {
 
         // Send GET request with a matching query param
         response = given().queryParam("q", queryParam)
-                .when().get(requestUrl)
+                .when().get(searchUrlBase)
                 .then().assertThat().statusCode(200)
                 .extract().response();
 
@@ -311,14 +319,10 @@ public class RouteListingTest extends AbstractTest {
         initSettings(); // Initialize routing rules
 
         String queryParam = "someQuery";
-        String routePath = "/routes";
-        String requestUrl = requestUrlBase + routePath;
-
         // No routes registered
-
         // Send GET request with a query param
         Response response = given().queryParam("q", queryParam)
-                .when().get(requestUrl)
+                .when().get(searchUrlBase)
                 .then().assertThat().statusCode(200)
                 .extract().response();
 

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/RouteListingTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/RouteListingTest.java
@@ -243,7 +243,7 @@ public class RouteListingTest extends AbstractTest {
         // Verify that the route was correctly registered
         Response response = given()
                 .queryParam("q", queryParam)
-                .when().get(requestUrl + "?q=" + queryParam)
+                .when().get(requestUrl )
                 .then().assertThat().statusCode(200)
                 .extract().response();
 
@@ -274,6 +274,7 @@ public class RouteListingTest extends AbstractTest {
         // Register a route using the addRoute method
         addRoute(queryParam, true, true);
         assertResponse(get(requestUrlBase), new String[]{queryParam+"/"});
+
         // Send GET request with a non-matching query param
         Response response = given().queryParam("q", nonMatchingQueryParam)
                 .when().get(requestUrl)
@@ -301,7 +302,7 @@ public class RouteListingTest extends AbstractTest {
 
         String queryParam = "someQuery";
         String routePath = "/routes";
-        String requestUrl = requestUrlBase + routePath + "?q=" + queryParam;
+        String requestUrl = requestUrlBase + routePath;
 
         // No routes registered
 
@@ -311,12 +312,9 @@ public class RouteListingTest extends AbstractTest {
                 .then().assertThat().statusCode(200)
                 .extract().response();
 
-        // Print the body of the response for debugging
-        System.out.println("Response body: " + response.getBody().asString());
-
         // Assert that the response body is empty or does not contain routes
-        Assert.assertTrue("No routes should be registered",
-                response.getBody().asString().contains("routes"));
+        Assert.assertFalse("No routes should be registered",
+                response.getBody().asString().contains(queryParam));
 
         async.complete();
     }

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/RouteListingTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/RouteListingTest.java
@@ -285,6 +285,16 @@ public class RouteListingTest extends AbstractTest {
         Assert.assertFalse("Non-matching query param should not be found in response",
                 response.getBody().asString().contains(nonMatchingQueryParam));
 
+        // Send GET request with a matching query param
+        response = given().queryParam("q", queryParam)
+                .when().get(requestUrl)
+                .then().assertThat().statusCode(200)
+                .extract().response();
+
+        // Assert the response contain the matching query param
+        Assert.assertTrue("matching query param should be found in response",
+                response.getBody().asString().contains(queryParam));
+
         // Unregister the route
         removeRoute(queryParam);
 

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/RouteListingTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/RouteListingTest.java
@@ -239,8 +239,6 @@ public class RouteListingTest extends AbstractTest {
                 response.getBody().asString().contains(queryParam));
 
         response = searchWithQueryParam("q", nonMatchingQueryParam, 200);
-        Assert.assertFalse("Non-matching query param should not be found in response",
-                response.getBody().asString().contains(nonMatchingQueryParam));
         JsonObject jsonResponse = new JsonObject(response.getBody().asString());
         Assert.assertTrue("Expected 'routes' to be an empty array",
                 jsonResponse.containsKey("routes") && jsonResponse.getJsonArray("routes").isEmpty());

--- a/gateleen-test/src/test/java/org/swisspush/gateleen/hook/RouteListingTest.java
+++ b/gateleen-test/src/test/java/org/swisspush/gateleen/hook/RouteListingTest.java
@@ -328,10 +328,10 @@ public class RouteListingTest extends AbstractTest {
         Assert.assertThat(array, Matchers.contains(expectedArray));
     }
 
-    private Response searchWithQueryParam(String searchParam, String queryParam, int expectedStatusCode ) {
+    private Response searchWithQueryParam(String queryParamName, String queryParamValue, int expectedStatusCode ) {
         return given()
-                .queryParam(searchParam, queryParam)
-                .when().get(searchUrlBase )
+                .queryParam(queryParamName, queryParamValue)
+                .when().get(searchUrlBase)
                 .then().assertThat().statusCode(expectedStatusCode)
                 .extract().response();
     }


### PR DESCRIPTION
### Documentation for the Hook Search API (Listeners and Routes)

Available Endpoints
1. Search Listeners

- Endpoint: /registrations/listeners
- HTTP Method: GET
- Description: Searches for all Listeners whose destination field contains the provided query string in the q parameter.

2. Search Routes

- Endpoint: /registrations/routes
- HTTP Method: GET
- Description: Searches for all Routes whose destination field contains the provided query string in the q parameter.

Query Parameter

Both endpoints support the q query parameter, which is used to filter the search results.

- q: A string to search for within the destination field of Listeners or Routes.

Example Request:
GET /registrations/listeners?q=myDestination
GET /registrations/routes?q=myDestination

Response Structure
Example Response - Searching for Listeners:

```
{
    "listeners": [
        "listener1",
        "listener2",
        "listener3"
    ]
}

```
Example Response - Searching for Routes:

```
{
    "routes": [
        "route1",
        "route2",
        "route3"
    ]
}
```


Key Features

1. Separate Endpoints for Listeners and Routes: The API provides distinct endpoints for Listeners and Routes searches, ensuring optimized search results based on specific hook types.

2. String-Based Search: The API looks for matches in the destination field of both Listeners and Routes. It searches for any substring match rather than an exact match, making the search more flexible.

3. Optimized Search Logic: The API uses efficient search mechanisms internally to quickly find results across registered listeners or routes, reducing response time even with large datasets.

Example Workflow

1. A client wants to find all Listeners with a destination that contains the string "myDestination". They make the following request:
GET /registrations/listeners?q=myDestination

2. The API returns a JSON object containing the identifiers of matching Listeners:
```
{
    "listeners": [
        "listener1",
        "listener2"
    ]
}
```



