### PR TITLE
#615 Made MonitoringHandler optional and added the same metrics with micrometer

### DIFF
--- a/gateleen-expansion/README_expansion.md
+++ b/gateleen-expansion/README_expansion.md
@@ -121,3 +121,27 @@ This allows you to create one octet-stream containing each json resource in the 
 Basically it works exactly the same way as the default expand feature works, except that it does not set an eTag for the request.
 
 > <font color="orange">Attention: </font> No eTag header is created / returned when this feature is used!
+
+### Micrometer metrics
+The expansion feature is monitored with micrometer. The following metrics are available:
+* gateleen_expand_requests_total
+* gateleen_storage_expand_requests_total
+
+For `expand_requests_total` additional tags are provided to specify the expand level.
+
+Example metrics:
+
+```
+# HELP gateleen_expand_requests_total  
+# TYPE gateleen_expand_requests_total counter
+gateleen_expand_requests_total{level="1",} 23677.0
+gateleen_expand_requests_total{level="2",} 2350.0
+gateleen_expand_requests_total{level="3",} 77.0
+gateleen_expand_requests_total{level="4",} 0.0
+gateleen_expand_requests_total{level="0",} 0.0
+# HELP gateleen_storage_expand_requests_total  
+# TYPE gateleen_storage_expand_requests_total counter
+gateleen_storage_expand_requests_total 37.0
+```
+
+To enable the metrics, set a `MeterRegistry` instance by calling `setMeterRegistry(MeterRegistry meterRegistry)` method in `ExpansionHandler` class.

--- a/gateleen-expansion/pom.xml
+++ b/gateleen-expansion/pom.xml
@@ -22,6 +22,10 @@
             <groupId>org.swisspush</groupId>
             <artifactId>rest-storage</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
 
         <!-- TEST dependencies -->
         <dependency>

--- a/gateleen-expansion/src/test/java/org/swisspush/gateleen/expansion/ExpansionHandlerTest.java
+++ b/gateleen-expansion/src/test/java/org/swisspush/gateleen/expansion/ExpansionHandlerTest.java
@@ -46,7 +46,6 @@ public class ExpansionHandlerTest {
     public void setUp() {
         vertx = Vertx.vertx();
         httpClient = Mockito.mock(HttpClient.class);
-    //    Mockito.when(httpClient.request(any(HttpMethod.class), anyString(), Matchers.<Handler<HttpClientResponse>>any())).thenReturn(Mockito.mock(HttpClientRequest.class));
         storage = new MockResourceStorage();
     }
 

--- a/gateleen-hook/README_hook.md
+++ b/gateleen-hook/README_hook.md
@@ -163,7 +163,7 @@ PUT http://myserver:7012/gateleen/everything/_hooks/listeners/http/myexample
     "destination": "/gateleen/example/thePosition",
     "filter": "/gateleen/everything/.*/position.*",
     "headers": [
-        { "header":"X-Expire-After", "value":"3600", mode:"complete"}
+        { "header":"X-Expire-After", "value":"3600", "mode":"complete"}
     ],
     "headersFilter": "x-foo: (A|B)"
 }
@@ -295,3 +295,21 @@ The response contains the matching routes, or an empty list if no match is found
   "routes": []
 }
 ```
+
+## Micrometer metrics
+The hook feature is monitored with micrometer. The following metrics are available:
+* gateleen_listener_count
+* gateleen_routes_count
+
+Example metrics:
+
+```
+# HELP gateleen_listener_count Amount of listener hooks currently registered
+# TYPE gateleen_listener_count gauge
+gateleen_listener_count 577.0
+# HELP gateleen_routes_count Amount of route hooks currently registered
+# TYPE gateleen_routes_count gauge
+gateleen_routes_count 15.0
+```
+
+To enable the metrics, set a `MeterRegistry` instance by calling `setMeterRegistry(MeterRegistry meterRegistry)` method in `HookHandler` class.

--- a/gateleen-hook/pom.xml
+++ b/gateleen-hook/pom.xml
@@ -17,6 +17,10 @@
             <artifactId>gateleen-queue</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
 
         <!-- TEST dependencies -->
         <dependency>

--- a/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
+++ b/gateleen-hook/src/main/java/org/swisspush/gateleen/hook/Route.java
@@ -1,6 +1,8 @@
 package org.swisspush.gateleen.hook;
 
-import io.vertx.codegen.annotations.Nullable;
+import javax.annotation.Nullable;
+
+import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -80,7 +82,7 @@ public class Route {
      * @param urlPattern - this can be a listener or a normal urlPattern (eg. for a route)
      */
     public Route(Vertx vertx, ResourceStorage storage, LoggingResourceManager loggingResourceManager,
-                 LogAppenderRepository logAppenderRepository, MonitoringHandler monitoringHandler, String userProfilePath,
+                 LogAppenderRepository logAppenderRepository, @Nullable MonitoringHandler monitoringHandler, String userProfilePath,
                  HttpHook httpHook, String urlPattern, HttpClient selfClient, String hookDisplayText) {
         this.vertx = vertx;
         this.storage = storage;
@@ -98,6 +100,10 @@ public class Route {
         createHttpClient();
 
         createForwarder();
+    }
+
+    public void setMeterRegistry(MeterRegistry meterRegistry) {
+        forwarder.setMeterRegistry(meterRegistry);
     }
 
     /**

--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueuingHandler.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueuingHandler.java
@@ -14,6 +14,8 @@ import org.swisspush.gateleen.queue.duplicate.DuplicateCheckHandler;
 import org.swisspush.gateleen.queue.queuing.splitter.NoOpQueueSplitter;
 import org.swisspush.gateleen.queue.queuing.splitter.QueueSplitter;
 
+import javax.annotation.Nullable;
+
 import static org.swisspush.redisques.util.RedisquesAPI.buildCheckOperation;
 
 /**
@@ -42,7 +44,7 @@ public class QueuingHandler implements Handler<Buffer> {
             Vertx vertx,
             RedisProvider redisProvider,
             HttpServerRequest request,
-            MonitoringHandler monitoringHandler
+            @Nullable MonitoringHandler monitoringHandler
     ) {
         this(vertx, redisProvider, request, new QueueClient(vertx, monitoringHandler), new NoOpQueueSplitter());
     }
@@ -51,7 +53,7 @@ public class QueuingHandler implements Handler<Buffer> {
             Vertx vertx,
             RedisProvider redisProvider,
             HttpServerRequest request,
-            MonitoringHandler monitoringHandler,
+            @Nullable MonitoringHandler monitoringHandler,
             QueueSplitter queueSplitter
     ) {
         this(

--- a/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueuingHandler.java
+++ b/gateleen-queue/src/main/java/org/swisspush/gateleen/queue/queuing/QueuingHandler.java
@@ -26,6 +26,7 @@ import static org.swisspush.redisques.util.RedisquesAPI.buildCheckOperation;
 public class QueuingHandler implements Handler<Buffer> {
 
     public static final String QUEUE_HEADER = "x-queue";
+    public static final String ORIGINALLY_QUEUED_HEADER = "x-originally-queued";
     public static final String DUPLICATE_CHECK_HEADER = "x-duplicate-check";
 
     private final RequestQueue requestQueue;
@@ -85,6 +86,9 @@ public class QueuingHandler implements Handler<Buffer> {
         final MultiMap headers = request.headers();
         // Remove the queue header to avoid feedback loop
         headers.remove(QUEUE_HEADER);
+
+        // Add a header to indicate that this request was initially queued
+        headers.add(ORIGINALLY_QUEUED_HEADER, "true");
 
         if (headers.names().contains(DUPLICATE_CHECK_HEADER)) {
             DuplicateCheckHandler.checkDuplicateRequest(redisProvider, request.uri(), buffer, headers.get(DUPLICATE_CHECK_HEADER), requestIsDuplicate -> {

--- a/gateleen-routing/README_routing.md
+++ b/gateleen-routing/README_routing.md
@@ -138,27 +138,43 @@ Each request header entry is validated in the format `<KEY>: <VALUE>`, so you ar
 
 ## Micrometer metrics
 The routing feature is monitored with micrometer. The following metrics are available:
-* gateleen_forwarded_requests_total
+* gateleen_forwarded_total
+* gateleen_forwarded_seconds
+* gateleen_forwarded_seconds_max
+* gateleen_forwarded_seconds_count
+* gateleen_forwarded_seconds_sum
 
 Additional tags are provided to split the forward count into sub counts.
 
 | tag        | description                                                                                                       |
 |------------|-------------------------------------------------------------------------------------------------------------------|
 | metricName | The `metricName` property from the corresponding routing rule. With this, you are able to count requests per rule |
-| type       | Describes where the request was forwarded to. Possible values are `local`, `external` and `null`                  |
+| type       | Describes where the request was forwarded to. Possible values are `local`, `external` and `null`                  |      
+| quantile   | Values of `0.75` and `0.95` for percentile durations of requests                                                  |
 
 
 Example metrics:
 
 ```
-# HELP gateleen_forwarded_requests_total Number of forwarded requests
-# TYPE gateleen_forwarded_requests_total counter
-gateleen_forwarded_requests_total{metricName="infotool_v1_informations",type="external",} 678765.0
-gateleen_forwarded_requests_total{metricName="amp-mutation",type="local",} 8875.0
-gateleen_forwarded_requests_total{metricName="edds-profile-houseservice-v2",type="storage",} 7777.0
-gateleen_forwarded_requests_total{metricName="password-reset",type="external",} 4.0
-gateleen_forwarded_requests_total{metricName="inventory-v1-session-start",type="external",} 0.0
-gateleen_forwarded_requests_total{metricName="edds-azb-catdir",type="null",} 5577.0
+# HELP gateleen_forwarded_total Amount of forwarded requests
+# TYPE gateleen_forwarded_total counter
+gateleen_forwarded_total{metricName="storage-resources",type="storage",} 67565.0
+gateleen_forwarded_total{metricName="infotool_v1_informations",type="external",} 655.0
+gateleen_forwarded_total{metricName="infotool-v1",type="storage",} 4320.0
+# HELP gateleen_forwarded_seconds_max Durations of forwarded requests
+# TYPE gateleen_forwarded_seconds_max gauge
+gateleen_forwarded_seconds_max{metricName="storage-resources",type="storage",} 8.5515
+gateleen_forwarded_seconds_max{metricName="infotool_v1_informations",type="external",} 3.456
+# HELP gateleen_forwarded_seconds Durations of forwarded requests
+# TYPE gateleen_forwarded_seconds summary
+gateleen_forwarded_seconds{metricName="storage-resources",type="storage",quantile="0.75",} 6.2158
+gateleen_forwarded_seconds{metricName="storage-resources",type="storage",quantile="0.95",} 8.2123
+gateleen_forwarded_seconds_count{metricName="storage-resources",type="storage",} 67565.0
+gateleen_forwarded_seconds_sum{metricName="storage-resources",type="storage",} 656434.0
+gateleen_forwarded_seconds{metricName="infotool_v1_informations",type="external",quantile="0.75",} 4.2365
+gateleen_forwarded_seconds{metricName="infotool_v1_informations",type="external",quantile="0.95",} 4.8998
+gateleen_forwarded_seconds_count{metricName="infotool_v1_informations",type="external",} 7567.0
+gateleen_forwarded_seconds_sum{metricName="infotool_v1_informations",type="external",} 256324.0
 ```
 
 To enable the metrics, set a `MeterRegistry` instance by calling `withMeterRegistry(MeterRegistry meterRegistry)` method in `RouterBuilder` class.

--- a/gateleen-routing/README_routing.md
+++ b/gateleen-routing/README_routing.md
@@ -135,3 +135,30 @@ Examples:
 }
 ```
 Each request header entry is validated in the format `<KEY>: <VALUE>`, so you are able to filter for request header names and values.
+
+## Micrometer metrics
+The routing feature is monitored with micrometer. The following metrics are available:
+* gateleen_forwarded_requests_total
+
+Additional tags are provided to split the forward count into sub counts.
+
+| tag        | description                                                                                                       |
+|------------|-------------------------------------------------------------------------------------------------------------------|
+| metricName | The `metricName` property from the corresponding routing rule. With this, you are able to count requests per rule |
+| type       | Describes where the request was forwarded to. Possible values are `local`, `external` and `null`                  |
+
+
+Example metrics:
+
+```
+# HELP gateleen_forwarded_requests_total Number of forwarded requests
+# TYPE gateleen_forwarded_requests_total counter
+gateleen_forwarded_requests_total{metricName="infotool_v1_informations",type="external",} 678765.0
+gateleen_forwarded_requests_total{metricName="amp-mutation",type="local",} 8875.0
+gateleen_forwarded_requests_total{metricName="edds-profile-houseservice-v2",type="storage",} 7777.0
+gateleen_forwarded_requests_total{metricName="password-reset",type="external",} 4.0
+gateleen_forwarded_requests_total{metricName="inventory-v1-session-start",type="external",} 0.0
+gateleen_forwarded_requests_total{metricName="edds-azb-catdir",type="null",} 5577.0
+```
+
+To enable the metrics, set a `MeterRegistry` instance by calling `withMeterRegistry(MeterRegistry meterRegistry)` method in `RouterBuilder` class.

--- a/gateleen-routing/pom.xml
+++ b/gateleen-routing/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>gateleen-monitoring</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
 
         <!-- TEST dependencies -->
         <dependency>

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/AbstractForwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/AbstractForwarder.java
@@ -23,8 +23,10 @@ public abstract class AbstractForwarder implements Handler<RoutingContext> {
     protected final MonitoringHandler monitoringHandler;
     protected final String metricNameTag;
 
-    public static final String FORWARDER_METRIC_NAME = "gateleen.forwarded.requests";
-    public static final String FORWARDER_METRIC_DESCRIPTION = "gateleen.forwarded.requests";
+    public static final String FORWARDER_COUNT_METRIC_NAME = "gateleen.forwarded";
+    public static final String FORWARDER_COUNT_METRIC_DESCRIPTION = "Amount of forwarded requests";
+    public static final String FORWARDS_METRIC_NAME = "gateleen.forwarded.seconds";
+    public static final String FORWARDS_METRIC_DESCRIPTION = "Durations of forwarded requests";
     public static final String FORWARDER_METRIC_TAG_TYPE = "type";
     public static final String FORWARDER_METRIC_TAG_METRICNAME = "metricName";
     public static final String FORWARDER_NO_METRICNAME = "no-metric-name";
@@ -43,10 +45,10 @@ public abstract class AbstractForwarder implements Handler<RoutingContext> {
     protected boolean doHeadersFilterMatch(final HttpServerRequest request) {
         final Logger log = RequestLoggerFactory.getLogger(getClass(), request);
 
-        if(rule.getHeadersFilterPattern() != null){
+        if (rule.getHeadersFilterPattern() != null) {
             log.debug("Looking for request headers with pattern {}", rule.getHeadersFilterPattern().pattern());
             boolean matchFound = HttpHeaderUtil.hasMatchingHeader(request.headers(), rule.getHeadersFilterPattern());
-            if(matchFound) {
+            if (matchFound) {
                 log.debug("Matching request headers found");
             } else {
                 log.debug("No matching request headers found. Looking for the next routing rule");
@@ -79,11 +81,10 @@ public abstract class AbstractForwarder implements Handler<RoutingContext> {
         }
     }
 
-    protected boolean isRequestToExternalTarget(String target) {
-        boolean isInternalRequest = false;
-        if (target != null) {
-            isInternalRequest = target.contains("localhost") || target.contains("127.0.0.1");
+    protected String getRequestTarget(String target) {
+        if (target != null && (target.contains("localhost") || target.contains("127.0.0.1"))) {
+            return "local";
         }
-        return !isInternalRequest;
+        return "external";
     }
 }

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/NullForwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/NullForwarder.java
@@ -46,8 +46,8 @@ public class NullForwarder extends AbstractForwarder {
     @Override
     public void setMeterRegistry(MeterRegistry meterRegistry) {
         if(meterRegistry != null) {
-            forwardCounter = Counter.builder(FORWARDER_METRIC_NAME)
-                    .description(FORWARDER_METRIC_DESCRIPTION)
+            forwardCounter = Counter.builder(FORWARDER_COUNT_METRIC_NAME)
+                    .description(FORWARDER_COUNT_METRIC_DESCRIPTION)
                     .tag(FORWARDER_METRIC_TAG_METRICNAME, metricNameTag)
                     .tag(FORWARDER_METRIC_TAG_TYPE, "null")
                     .register(meterRegistry);

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RouterBuilder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/RouterBuilder.java
@@ -1,5 +1,6 @@
 package org.swisspush.gateleen.routing;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
@@ -37,6 +38,7 @@ public class RouterBuilder {
     private LoggingResourceManager loggingResourceManager;
     private LogAppenderRepository logAppenderRepository;
     private MonitoringHandler monitoringHandler;
+    private MeterRegistry meterRegistry;
     private HttpClient selfClient;
     private String serverPath;
     private String rulesPath;
@@ -98,6 +100,7 @@ public class RouterBuilder {
                 loggingResourceManager,
                 logAppenderRepository,
                 monitoringHandler,
+                meterRegistry,
                 selfClient,
                 serverPath,
                 rulesPath,
@@ -180,6 +183,12 @@ public class RouterBuilder {
     public RouterBuilder withMonitoringHandler(MonitoringHandler monitoringHandler) {
         ensureNotBuilt();
         this.monitoringHandler = monitoringHandler;
+        return this;
+    }
+
+    public RouterBuilder withMeterRegistry(MeterRegistry meterRegistry) {
+        ensureNotBuilt();
+        this.meterRegistry = meterRegistry;
         return this;
     }
 

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/StorageForwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/StorageForwarder.java
@@ -1,5 +1,7 @@
 package org.swisspush.gateleen.routing;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -28,6 +30,7 @@ import org.swisspush.gateleen.logging.LoggingHandler;
 import org.swisspush.gateleen.logging.LoggingResourceManager;
 import org.swisspush.gateleen.monitoring.MonitoringHandler;
 
+import javax.annotation.Nullable;
 import java.util.regex.Pattern;
 
 /**
@@ -43,8 +46,10 @@ public class StorageForwarder extends AbstractForwarder {
     private CORSHandler corsHandler;
     private GateleenExceptionFactory gateleenExceptionFactory;
 
+    private Counter forwardCounter;
+
     public StorageForwarder(EventBus eventBus, Rule rule, LoggingResourceManager loggingResourceManager,
-                            LogAppenderRepository logAppenderRepository, MonitoringHandler monitoringHandler,
+                            LogAppenderRepository logAppenderRepository, @Nullable MonitoringHandler monitoringHandler,
                             GateleenExceptionFactory gateleenExceptionFactory) {
         super(rule, loggingResourceManager, logAppenderRepository, monitoringHandler);
         this.eventBus = eventBus;
@@ -52,6 +57,24 @@ public class StorageForwarder extends AbstractForwarder {
         urlPattern = Pattern.compile(rule.getUrlPattern());
         corsHandler = new CORSHandler();
         this.gateleenExceptionFactory = gateleenExceptionFactory;
+    }
+
+    /**
+     * Sets the MeterRegistry for this StorageForwarder.
+     * If the provided MeterRegistry is not null, it initializes the forwardCounter
+     * with the appropriate metric name, description, and tags.
+     *
+     * @param meterRegistry the MeterRegistry to set
+     */
+    @Override
+    public void setMeterRegistry(MeterRegistry meterRegistry) {
+        if (meterRegistry != null) {
+            forwardCounter = Counter.builder(FORWARDER_METRIC_NAME)
+                    .description(FORWARDER_METRIC_DESCRIPTION)
+                    .tag(FORWARDER_METRIC_TAG_METRICNAME, metricNameTag)
+                    .tag(FORWARDER_METRIC_TAG_TYPE, "storage")
+                    .register(meterRegistry);
+        }
     }
 
     @Override
@@ -65,9 +88,17 @@ public class StorageForwarder extends AbstractForwarder {
             return;
         }
 
-        monitoringHandler.updateRequestsMeter("localhost", ctx.request().uri());
-        monitoringHandler.updateRequestPerRuleMonitoring(ctx.request(), rule.getMetricName());
-        final long startTime = monitoringHandler.startRequestMetricTracking(rule.getMetricName(), ctx.request().uri());
+        Long startTime = null;
+
+        if (forwardCounter != null) {
+            forwardCounter.increment();
+        }
+
+        if (monitoringHandler != null) {
+            monitoringHandler.updateRequestsMeter("localhost", ctx.request().uri());
+            monitoringHandler.updateRequestPerRuleMonitoring(ctx.request(), rule.getMetricName());
+            startTime = monitoringHandler.startRequestMetricTracking(rule.getMetricName(), ctx.request().uri());
+        }
         log.debug("Forwarding {} request: {} to storage {} {} with rule {}", ctx.request().method(), ctx.request().uri(),
                 rule.getStorage(), targetUri, rule.getRuleIdentifier());
         final HeadersMultiMap requestHeaders = new HeadersMultiMap();
@@ -92,68 +123,71 @@ public class StorageForwarder extends AbstractForwarder {
             loggingHandler.appendRequestPayload(buffer, requestHeaders);
             requestBuffer.appendBuffer(buffer);
         });
+        Long finalStartTime = startTime;
         ctx.request().endHandler(event ->
                 eventBus.request(address, requestBuffer, new DeliveryOptions().setSendTimeout(10000),
                         (Handler<AsyncResult<Message<Buffer>>>) result -> {
-                HttpServerResponse response = ctx.response();
-                monitoringHandler.stopRequestMetricTracking(rule.getMetricName(), startTime, ctx.request().uri());
-                if (result.failed()) {
-                    String statusMessage = "Storage request for " + ctx.request().uri() + " failed with message: " + result.cause().getMessage();
-                    response.setStatusCode(StatusCode.INTERNAL_SERVER_ERROR.getStatusCode());
-                    response.setStatusMessage(statusMessage);
-                    response.end();
-                    log.error("{}", statusMessage, gateleenExceptionFactory.newException(result.cause()));
-                } else {
-                    Buffer buffer = result.result().body();
-                    int headerLength = buffer.getInt(0);
-                    JsonObject responseJson = new JsonObject(buffer.getString(4, headerLength + 4));
-                    JsonArray headers = responseJson.getJsonArray("headers");
-                    MultiMap responseHeaders = null;
-                    if (headers != null && !headers.isEmpty()) {
-                        responseHeaders = JsonMultiMap.fromJson(headers);
+                            HttpServerResponse response = ctx.response();
+                            if (monitoringHandler != null) {
+                                monitoringHandler.stopRequestMetricTracking(rule.getMetricName(), finalStartTime, ctx.request().uri());
+                            }
+                            if (result.failed()) {
+                                String statusMessage = "Storage request for " + ctx.request().uri() + " failed with message: " + result.cause().getMessage();
+                                response.setStatusCode(StatusCode.INTERNAL_SERVER_ERROR.getStatusCode());
+                                response.setStatusMessage(statusMessage);
+                                response.end();
+                                log.error("{}", statusMessage, gateleenExceptionFactory.newException(result.cause()));
+                            } else {
+                                Buffer buffer = result.result().body();
+                                int headerLength = buffer.getInt(0);
+                                JsonObject responseJson = new JsonObject(buffer.getString(4, headerLength + 4));
+                                JsonArray headers = responseJson.getJsonArray("headers");
+                                MultiMap responseHeaders = null;
+                                if (headers != null && !headers.isEmpty()) {
+                                    responseHeaders = JsonMultiMap.fromJson(headers);
 
-                        setUniqueIdHeader(responseHeaders);
+                                    setUniqueIdHeader(responseHeaders);
 
-                        ctx.response().headers().setAll(responseHeaders);
-                    }
-                    corsHandler.handle(ctx.request());
-                    int statusCode = responseJson.getInteger("statusCode");
+                                    ctx.response().headers().setAll(responseHeaders);
+                                }
+                                corsHandler.handle(ctx.request());
+                                int statusCode = responseJson.getInteger("statusCode");
 
-                    // translate with header info
-                    int translatedStatus = Translator.translateStatusCode(statusCode, ctx.request().headers());
+                                // translate with header info
+                                int translatedStatus = Translator.translateStatusCode(statusCode, ctx.request().headers());
 
-                    // nothing changed?
-                    if (statusCode == translatedStatus) {
-                        translatedStatus = Translator.translateStatusCode(statusCode, rule, log);
-                    }
+                                // nothing changed?
+                                if (statusCode == translatedStatus) {
+                                    translatedStatus = Translator.translateStatusCode(statusCode, rule, log);
+                                }
 
-                    boolean translated = statusCode != translatedStatus;
+                                boolean translated = statusCode != translatedStatus;
 
-                    // set the statusCode (if nothing hapend, it will remain the same)
-                    statusCode = translatedStatus;
+                                // set the statusCode (if nothing hapend, it will remain the same)
+                                statusCode = translatedStatus;
 
-                    response.setStatusCode(statusCode);
-                    String statusMessage;
-                    if (translated) {
-                        statusMessage = HttpResponseStatus.valueOf(statusCode).reasonPhrase();
-                        response.setStatusMessage(statusMessage);
-                    } else {
-                        statusMessage = responseJson.getString("statusMessage");
-                        if (statusMessage != null) {
-                            response.setStatusMessage(statusMessage);
-                        }
-                    }
-                    Buffer data = buffer.getBuffer(4 + headerLength, buffer.length());
-                    response.headers().set("content-length", "" + data.length());
-                    response.write(data);
-                    response.end();
-                    ResponseStatusCodeLogUtil.debug(ctx.request(), StatusCode.fromCode(statusCode), StorageForwarder.class);
-                    if (responseHeaders != null) {
-                        loggingHandler.appendResponsePayload(data, responseHeaders);
-                    }
-                    loggingHandler.log(ctx.request().uri(), ctx.request().method(), statusCode, statusMessage,
-                            requestHeaders, responseHeaders != null ? responseHeaders : new HeadersMultiMap());
-                }
+                                response.setStatusCode(statusCode);
+                                String statusMessage;
+                                if (translated) {
+                                    statusMessage = HttpResponseStatus.valueOf(statusCode).reasonPhrase();
+                                    response.setStatusMessage(statusMessage);
+                                } else {
+                                    statusMessage = responseJson.getString("statusMessage");
+                                    if (statusMessage != null) {
+                                        response.setStatusMessage(statusMessage);
+                                    }
+                                }
+                                Buffer data = buffer.getBuffer(4 + headerLength, buffer.length());
+                                response.headers().set("content-length", "" + data.length());
+                                response.write(data);
+                                response.end();
+                                ResponseStatusCodeLogUtil.debug(ctx.request(), StatusCode.fromCode(statusCode), StorageForwarder.class);
+                                if (responseHeaders != null) {
+                                    loggingHandler.appendResponsePayload(data, responseHeaders);
+                                }
+                                loggingHandler.log(ctx.request().uri(), ctx.request().method(), statusCode, statusMessage,
+                                        requestHeaders, responseHeaders != null ? responseHeaders : new HeadersMultiMap());
+                            }
 
                         }));
     }

--- a/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/RouterTest.java
+++ b/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/RouterTest.java
@@ -1,6 +1,9 @@
 package org.swisspush.gateleen.routing;
 
 import com.google.common.collect.ImmutableMap;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
@@ -28,10 +31,7 @@ import org.swisspush.gateleen.logging.LoggingResource;
 import org.swisspush.gateleen.logging.LoggingResourceManager;
 import org.swisspush.gateleen.monitoring.MonitoringHandler;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Tests for the Router class
@@ -45,6 +45,7 @@ public class RouterTest {
     private Map<String, Object> properties;
     private LoggingResourceManager loggingResourceManager;
     private MonitoringHandler monitoringHandler;
+    private MeterRegistry meterRegistry;
     private HttpClient httpClient;
     private String serverUrl;
     private String rulesPath;
@@ -143,6 +144,7 @@ public class RouterTest {
         Mockito.when(loggingResourceManager.getLoggingResource()).thenReturn(new LoggingResource());
         monitoringHandler = Mockito.mock(MonitoringHandler.class);
         httpClient = Mockito.mock(HttpClient.class);
+        meterRegistry = new SimpleMeterRegistry();
 
         serverUrl = "/gateleen/server";
         rulesPath = serverUrl + "/admin/v1/routing/rules";
@@ -160,12 +162,19 @@ public class RouterTest {
                 .withProperties(properties)
                 .withLoggingResourceManager(loggingResourceManager)
                 .withMonitoringHandler(monitoringHandler)
+                .withMeterRegistry(meterRegistry)
                 .withSelfClient(httpClient)
                 .withServerPath(serverUrl)
                 .withRulesPath(rulesPath)
                 .withUserProfilePath(userProfilePath)
                 .withInfo(info)
                 .withStoragePort(storagePort);
+    }
+
+    private void assertNoCountersIncremented(TestContext context) {
+        for (Counter counter : meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).counters()) {
+            context.assertEquals(0.0, counter.count(), "No counter should have been incremented");
+        }
     }
 
     @Test
@@ -239,6 +248,9 @@ public class RouterTest {
         }
         GETRandomResourceRequest request = new GETRandomResourceRequest();
         router.route(request);
+
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "loop_4").counter();
+        context.assertEquals(1.0, counter.count(), "Counter for `loop_4` rule should have been incremented by 1");
 
         context.assertEquals("1", request.headers().get("x-hops"), "x-hops header should have value 1");
         context.assertEquals(StatusCode.OK.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 200");
@@ -316,6 +328,8 @@ public class RouterTest {
         }
         GETRandomResourceRequest request = new GETRandomResourceRequest();
         router.route(request);
+
+        assertNoCountersIncremented(context);
 
         context.assertEquals("1", request.headers().get("x-hops"), "x-hops header should have value 1");
         context.assertEquals(StatusCode.INTERNAL_SERVER_ERROR.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 500");
@@ -404,6 +418,9 @@ public class RouterTest {
         context.assertEquals("6", request.headers().get("x-hops"), "x-hops header should have value 6");
         context.assertEquals(StatusCode.INTERNAL_SERVER_ERROR.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 500");
         context.assertEquals("Request hops limit exceeded", request.response().getStatusMessage(), "StatusMessage should be 'Request hops limit exceeded'");
+
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "loop_4").counter();
+        context.assertEquals(5.0, counter.count(), "Counter for `loop_4` rule should have been incremented by 5");
     }
 
     @Test
@@ -478,6 +495,9 @@ public class RouterTest {
         context.assertNull(request.headers().get("x-hops"), "No x-hops header should be present");
         context.assertEquals(StatusCode.OK.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 200");
         context.assertEquals(StatusCode.OK.getStatusMessage(), request.response().getStatusMessage(), "StatusMessage should be OK");
+
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "loop_4").counter();
+        context.assertEquals(20.0, counter.count(), "Counter for `loop_4` rule should have been incremented by 20");
     }
 
 
@@ -488,6 +508,8 @@ public class RouterTest {
         Router router = routerBuilder().withProperties(properties).build();
         context.assertFalse(router.isRoutingBroken(), "Routing should not be broken");
         context.assertNull(router.getRoutingBrokenMessage(), "RoutingBrokenMessage should be null");
+
+        assertNoCountersIncremented(context);
     }
 
     @Test
@@ -496,6 +518,8 @@ public class RouterTest {
         context.assertTrue(router.isRoutingBroken(), "Routing should be broken because of missing properties entry");
         context.assertNotNull(router.getRoutingBrokenMessage(), "RoutingBrokenMessage should contain 'gateleen.test.prop.1' property");
         context.assertTrue(router.getRoutingBrokenMessage().contains("gateleen.test.prop.1"), "RoutingBrokenMessage should contain 'gateleen.test.prop.1' property");
+
+        assertNoCountersIncremented(context);
     }
 
     @Test
@@ -538,6 +562,8 @@ public class RouterTest {
         router.route(new UpdateRulesWithValidResourceRequest());
         context.assertFalse(router.isRoutingBroken(), "Routing should not be broken anymore");
         context.assertNull(router.getRoutingBrokenMessage(), "RoutingBrokenMessage should be null");
+
+        assertNoCountersIncremented(context);
     }
 
     @Test
@@ -578,6 +604,8 @@ public class RouterTest {
         context.assertEquals(StatusCode.OK.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 200");
         context.assertEquals(StatusCode.OK.getStatusMessage(), request.response().getStatusMessage(), "StatusMessage should be OK");
         context.assertEquals(RULES_WITH_MISSING_PROPS, request.response().getResultBuffer(), "RoutingRules should be returned as result");
+
+        assertNoCountersIncremented(context);
     }
 
     @Test
@@ -619,6 +647,8 @@ public class RouterTest {
         context.assertEquals(StatusCode.INTERNAL_SERVER_ERROR.getStatusMessage(), request.response().getStatusMessage(), "StatusMessage should be Internal Server Error");
         context.assertTrue(request.response().getResultBuffer().contains("Routing is broken"), "Routing is broken message should be returned");
         context.assertTrue(request.response().getResultBuffer().contains("gateleen.test.prop.1"), "The message should contain 'gateleen.test.prop.1' in the message");
+
+        assertNoCountersIncremented(context);
     }
 
     @Test
@@ -742,6 +772,9 @@ public class RouterTest {
         router.route(requestRandomResource);
         context.assertFalse(router.isRoutingBroken(), "Routing should not be broken anymore");
         context.assertNull(router.getRoutingBrokenMessage(), "RoutingBrokenMessage should be null");
+
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_TYPE, "local").counter();
+        context.assertEquals(1.0, counter.count(), "Counter should have been incremented by 1");
     }
 
     @Test
@@ -793,6 +826,8 @@ public class RouterTest {
         context.assertEquals(StatusCode.OK.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 200");
         context.assertEquals(StatusCode.OK.getStatusMessage(), request.response().getStatusMessage(), "StatusMessage should be OK");
         context.assertEquals(ts, new JsonObject(request.response().getResultBuffer()).getLong("ts"));
+
+        assertNoCountersIncremented(context);
     }
 
     @Test
@@ -848,6 +883,7 @@ public class RouterTest {
         router.route(request);
 
         context.assertEquals(StatusCode.NOT_FOUND.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 404");
+        assertNoCountersIncremented(context);
     }
 
     @Test
@@ -871,6 +907,9 @@ public class RouterTest {
 
         context.assertEquals(StatusCode.OK.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 200");
         context.assertEquals(StatusCode.OK.getStatusMessage(), request.response().getStatusMessage(), "StatusMessage should be OK");
+
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "forward_storage").counter();
+        context.assertEquals(1.0, counter.count(), "Counter for `forward_storage` rule should have been incremented by 1");
     }
 
     @Test
@@ -892,6 +931,8 @@ public class RouterTest {
         router.route(request);
 
         context.assertEquals(StatusCode.NOT_FOUND.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 404");
+
+        assertNoCountersIncremented(context);
     }
 
     @Test
@@ -914,6 +955,8 @@ public class RouterTest {
         router.route(request);
 
         context.assertEquals(StatusCode.NOT_FOUND.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 404");
+
+        assertNoCountersIncremented(context);
     }
 
     @Test
@@ -938,6 +981,9 @@ public class RouterTest {
 
         context.assertEquals(StatusCode.OK.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 200");
         context.assertEquals(StatusCode.OK.getStatusMessage(), request.response().getStatusMessage(), "StatusMessage should be OK");
+
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "forward_null").counter();
+        context.assertEquals(1.0, counter.count(), "Counter for `forward_null` rule should have been incremented by 1");
     }
 
     @Test
@@ -963,6 +1009,9 @@ public class RouterTest {
         // we expect a status code 500 because of a NullPointerException in the test setup
         // however, this means that the headersFilter evaluation did not return a 400 Bad Request
         context.assertEquals(StatusCode.INTERNAL_SERVER_ERROR.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 500");
+
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "forward_backend").counter();
+        context.assertEquals(1.0, counter.count(), "Counter for `forward_backend` rule should have been incremented by 1");
     }
 
     @Test
@@ -986,6 +1035,8 @@ public class RouterTest {
         router.route(request);
 
         context.assertEquals(StatusCode.NOT_FOUND.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 404");
+
+        assertNoCountersIncremented(context);
     }
 
     private DummyHttpServerRequest buildRequest(HttpMethod method, String uri, MultiMap headers, Buffer body, DummyHttpServerResponse response) {

--- a/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/RouterTest.java
+++ b/gateleen-routing/src/test/java/org/swisspush/gateleen/routing/RouterTest.java
@@ -172,7 +172,7 @@ public class RouterTest {
     }
 
     private void assertNoCountersIncremented(TestContext context) {
-        for (Counter counter : meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).counters()) {
+        for (Counter counter : meterRegistry.get(AbstractForwarder.FORWARDER_COUNT_METRIC_NAME).counters()) {
             context.assertEquals(0.0, counter.count(), "No counter should have been incremented");
         }
     }
@@ -249,7 +249,7 @@ public class RouterTest {
         GETRandomResourceRequest request = new GETRandomResourceRequest();
         router.route(request);
 
-        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "loop_4").counter();
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_COUNT_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "loop_4").counter();
         context.assertEquals(1.0, counter.count(), "Counter for `loop_4` rule should have been incremented by 1");
 
         context.assertEquals("1", request.headers().get("x-hops"), "x-hops header should have value 1");
@@ -419,7 +419,7 @@ public class RouterTest {
         context.assertEquals(StatusCode.INTERNAL_SERVER_ERROR.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 500");
         context.assertEquals("Request hops limit exceeded", request.response().getStatusMessage(), "StatusMessage should be 'Request hops limit exceeded'");
 
-        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "loop_4").counter();
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_COUNT_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "loop_4").counter();
         context.assertEquals(5.0, counter.count(), "Counter for `loop_4` rule should have been incremented by 5");
     }
 
@@ -496,7 +496,7 @@ public class RouterTest {
         context.assertEquals(StatusCode.OK.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 200");
         context.assertEquals(StatusCode.OK.getStatusMessage(), request.response().getStatusMessage(), "StatusMessage should be OK");
 
-        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "loop_4").counter();
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_COUNT_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "loop_4").counter();
         context.assertEquals(20.0, counter.count(), "Counter for `loop_4` rule should have been incremented by 20");
     }
 
@@ -773,7 +773,7 @@ public class RouterTest {
         context.assertFalse(router.isRoutingBroken(), "Routing should not be broken anymore");
         context.assertNull(router.getRoutingBrokenMessage(), "RoutingBrokenMessage should be null");
 
-        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_TYPE, "local").counter();
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_COUNT_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_TYPE, "local").counter();
         context.assertEquals(1.0, counter.count(), "Counter should have been incremented by 1");
     }
 
@@ -908,7 +908,7 @@ public class RouterTest {
         context.assertEquals(StatusCode.OK.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 200");
         context.assertEquals(StatusCode.OK.getStatusMessage(), request.response().getStatusMessage(), "StatusMessage should be OK");
 
-        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "forward_storage").counter();
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_COUNT_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "forward_storage").counter();
         context.assertEquals(1.0, counter.count(), "Counter for `forward_storage` rule should have been incremented by 1");
     }
 
@@ -982,7 +982,7 @@ public class RouterTest {
         context.assertEquals(StatusCode.OK.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 200");
         context.assertEquals(StatusCode.OK.getStatusMessage(), request.response().getStatusMessage(), "StatusMessage should be OK");
 
-        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "forward_null").counter();
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_COUNT_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "forward_null").counter();
         context.assertEquals(1.0, counter.count(), "Counter for `forward_null` rule should have been incremented by 1");
     }
 
@@ -1010,7 +1010,7 @@ public class RouterTest {
         // however, this means that the headersFilter evaluation did not return a 400 Bad Request
         context.assertEquals(StatusCode.INTERNAL_SERVER_ERROR.getStatusCode(), request.response().getStatusCode(), "StatusCode should be 500");
 
-        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "forward_backend").counter();
+        Counter counter = meterRegistry.get(AbstractForwarder.FORWARDER_COUNT_METRIC_NAME).tag(AbstractForwarder.FORWARDER_METRIC_TAG_METRICNAME, "forward_backend").counter();
         context.assertEquals(1.0, counter.count(), "Counter for `forward_backend` rule should have been incremented by 1");
     }
 

--- a/gateleen-scheduler/src/main/java/org/swisspush/gateleen/scheduler/Scheduler.java
+++ b/gateleen-scheduler/src/main/java/org/swisspush/gateleen/scheduler/Scheduler.java
@@ -15,6 +15,7 @@ import org.swisspush.gateleen.monitoring.MonitoringHandler;
 import org.swisspush.gateleen.queue.expiry.ExpiryCheckHandler;
 import org.swisspush.gateleen.queue.queuing.QueueClient;
 
+import javax.annotation.Nullable;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
@@ -48,17 +49,17 @@ public class Scheduler {
     private Logger log;
 
     public Scheduler(
-        Vertx vertx,
-        String redisquesAddress,
-        RedisProvider redisProvider,
-        GateleenExceptionFactory exceptionFactory,
-        String name,
-        String cronExpression,
-        List<HttpRequest> requests,
-        MonitoringHandler monitoringHandler,
-        int maxRandomOffset,
-        boolean executeOnStartup,
-        boolean executeOnReload
+            Vertx vertx,
+            String redisquesAddress,
+            RedisProvider redisProvider,
+            GateleenExceptionFactory exceptionFactory,
+            String name,
+            String cronExpression,
+            List<HttpRequest> requests,
+            @Nullable MonitoringHandler monitoringHandler,
+            int maxRandomOffset,
+            boolean executeOnStartup,
+            boolean executeOnReload
     ) throws ParseException {
         this.vertx = vertx;
         this.redisquesAddress = redisquesAddress;
@@ -138,7 +139,9 @@ public class Scheduler {
 
     private void trigger() {
         for (final HttpRequest request : requests) {
-            monitoringHandler.updateEnqueue();
+            if (monitoringHandler != null) {
+                monitoringHandler.updateEnqueue();
+            }
 
             if (log.isTraceEnabled()) {
                 log.trace("Triggering request " + request.toJsonObject().encodePrettily());
@@ -156,7 +159,7 @@ public class Scheduler {
                 if (event.failed()) {
                     if (log.isWarnEnabled()) {
                         log.warn("Could not enqueue request '{}' '{}'", queueName, request.getUri(),
-                            exceptionFactory.newException("eventBus.request('" + redisquesAddress + "', enqueOp) failed", event.cause()));
+                                exceptionFactory.newException("eventBus.request('" + redisquesAddress + "', enqueOp) failed", event.cause()));
                     }
                     return;
                 }

--- a/gateleen-scheduler/src/main/java/org/swisspush/gateleen/scheduler/SchedulerFactory.java
+++ b/gateleen-scheduler/src/main/java/org/swisspush/gateleen/scheduler/SchedulerFactory.java
@@ -15,6 +15,7 @@ import org.swisspush.gateleen.monitoring.MonitoringHandler;
 import org.swisspush.gateleen.validation.ValidationException;
 import org.swisspush.gateleen.validation.Validator;
 
+import javax.annotation.Nullable;
 import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -54,7 +55,7 @@ public class SchedulerFactory {
         Vertx vertx,
         RedisProvider redisProvider,
         GateleenExceptionFactory exceptionFactory,
-        MonitoringHandler monitoringHandler,
+        @Nullable MonitoringHandler monitoringHandler,
         String schedulersSchema,
         String redisquesAddress
     ) {

--- a/gateleen-scheduler/src/main/java/org/swisspush/gateleen/scheduler/SchedulerResourceManager.java
+++ b/gateleen-scheduler/src/main/java/org/swisspush/gateleen/scheduler/SchedulerResourceManager.java
@@ -21,6 +21,7 @@ import org.swisspush.gateleen.core.util.StatusCode;
 import org.swisspush.gateleen.monitoring.MonitoringHandler;
 import org.swisspush.gateleen.validation.ValidationException;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -44,17 +45,17 @@ public class SchedulerResourceManager implements Refreshable, LoggableResource {
     private boolean logConfigurationResourceChanges = false;
 
     public SchedulerResourceManager(Vertx vertx, RedisProvider redisProvider, final ResourceStorage storage,
-                                    MonitoringHandler monitoringHandler, String schedulersUri) {
+                                    @Nullable MonitoringHandler monitoringHandler, String schedulersUri) {
         this(vertx, redisProvider, storage, monitoringHandler, schedulersUri, null);
     }
 
     public SchedulerResourceManager(Vertx vertx, RedisProvider redisProvider, final ResourceStorage storage,
-                                    MonitoringHandler monitoringHandler, String schedulersUri, Map<String,Object> props) {
+                                    @Nullable MonitoringHandler monitoringHandler, String schedulersUri, Map<String,Object> props) {
         this(vertx, redisProvider, storage, monitoringHandler, schedulersUri, props, Address.redisquesAddress());
     }
 
     public SchedulerResourceManager(Vertx vertx, RedisProvider redisProvider, final ResourceStorage storage,
-                                    MonitoringHandler monitoringHandler, String schedulersUri, Map<String,Object> props,
+                                    @Nullable MonitoringHandler monitoringHandler, String schedulersUri, Map<String,Object> props,
                                     String redisquesAddress) {
         this(vertx, redisProvider, newGateleenThriftyExceptionFactory(), storage, monitoringHandler, schedulersUri, props, redisquesAddress, Collections.emptyMap());
     }
@@ -64,7 +65,7 @@ public class SchedulerResourceManager implements Refreshable, LoggableResource {
         RedisProvider redisProvider,
         GateleenExceptionFactory exceptionFactory,
         ResourceStorage storage,
-        MonitoringHandler monitoringHandler,
+        @Nullable MonitoringHandler monitoringHandler,
         String schedulersUri,
         Map<String, Object> props,
         String redisquesAddress,

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <json-smart.version>2.4.10</json-smart.version>
         <joda.version>2.12.6</joda.version>
         <jsonpath.version>2.9.0</jsonpath.version>
+        <micrometer.version>1.12.13</micrometer.version>
         <mockito.version>5.8.0</mockito.version>
         <mod-metrics.version>3.0.0</mod-metrics.version>
         <networknt.version>0.1.15</networknt.version>
@@ -357,6 +358,11 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j2-impl</artifactId>
                 <version>${log4j-slf4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-core</artifactId>
+                <version>${micrometer.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.swisspush</groupId>


### PR DESCRIPTION
The MonitoringHandler class uses JMX/EventBus to publish metrics. Since we don't want to use JMX anymore, I made the MonitoringHandler class optional, so it does not have to be provided.

On the other side, I added the metrics directly to the gateleen modules. Monitoring with micrometer is also optional and disabled per default.