### PR TITLE
Bug 618 response handler in forwarder called twice per request

### DIFF
--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
@@ -313,6 +313,7 @@ public class Forwarder extends AbstractForwarder {
                 }
                 HttpClientRequest cReq = event.result();
                 final Handler<AsyncResult<HttpClientResponse>> cResHandler = getAsyncHttpClientResponseHandler(req, targetUri, log, profileHeaderMap, loggingHandler, finalStartTime, finalTimerSample, afterHandler);
+                cReq.response(cResHandler);
 
                 if (timeout != null) {
                     cReq.idleTimeout(Long.parseLong(timeout));
@@ -443,16 +444,16 @@ public class Forwarder extends AbstractForwarder {
                         // Setting the endHandler would then lead to an Exception
                         // see also https://github.com/eclipse-vertx/vert.x/issues/2763
                         // so we now check if the request already is ended before installing an endHandler
-                        cReq.send(cResHandler);
+                        cReq.send();
                     } else {
-                        req.endHandler(v -> cReq.send(cResHandler));
+                        req.endHandler(v -> cReq.send());
                         pump.start();
                     }
                 } else {
                     loggingHandler.appendRequestPayload(bodyData);
                     // we already have the body complete in-memory - so we can use Content-Length header and avoid chunked transfer
                     cReq.putHeader(HttpHeaders.CONTENT_LENGTH, Integer.toString(bodyData.length()));
-                    cReq.send(bodyData, cResHandler);
+                    cReq.send(bodyData);
                 }
 
                 loggingHandler.request(cReq.headers());

--- a/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
+++ b/gateleen-routing/src/main/java/org/swisspush/gateleen/routing/Forwarder.java
@@ -313,7 +313,6 @@ public class Forwarder extends AbstractForwarder {
                 }
                 HttpClientRequest cReq = event.result();
                 final Handler<AsyncResult<HttpClientResponse>> cResHandler = getAsyncHttpClientResponseHandler(req, targetUri, log, profileHeaderMap, loggingHandler, finalStartTime, finalTimerSample, afterHandler);
-                cReq.response(cResHandler);
 
                 if (timeout != null) {
                     cReq.idleTimeout(Long.parseLong(timeout));
@@ -358,7 +357,7 @@ public class Forwarder extends AbstractForwarder {
                  */
                 if (bodyData == null) {
 
-                    // Gateleen internal requests (e.g. from scedulers or delegates) often have neither "Content-Length" nor "Transfer-Encoding: chunked"
+                    // Gateleen internal requests (e.g. from schedulers or delegates) often have neither "Content-Length" nor "Transfer-Encoding: chunked"
                     // header - so we must wait for a body buffer to know: Is there a body or not? Only looking on the headers and/or the http-method is not
                     // sustainable to know "has body or not"
                     // But: if there is a body, then we need to either setChunked or a Content-Length header (otherwise Vertx complains with an Exception)


### PR DESCRIPTION
On line 316, just after creating it, the cResHandler is added as a response handler to the cReq. No need to add it again when sending the request.
At first at removed it on line 316, since we add in while sending, but that doesn't work, because in some cases the pump starts writing the request before the send method is called and if the server already answers before the send is called, we would have no response handler installed.
This happens when forwarding to /server/return-with-status-code/503