### PR TITLE
replaced unnecessary publish with send

### DIFF
--- a/gateleen-monitoring/src/main/java/org/swisspush/gateleen/monitoring/EventBusMetricsPublisher.java
+++ b/gateleen-monitoring/src/main/java/org/swisspush/gateleen/monitoring/EventBusMetricsPublisher.java
@@ -17,7 +17,7 @@ public class EventBusMetricsPublisher implements MetricsPublisher {
 
     @Override
     public void publishMetric(String name, long value) {
-        vertx.eventBus().publish(monitoringAddress,
+        vertx.eventBus().send(monitoringAddress,
                 new JsonObject().put("name", prefix + name).put("action", "set").put("n", value));
     }
 }

--- a/gateleen-monitoring/src/main/java/org/swisspush/gateleen/monitoring/MonitoringHandler.java
+++ b/gateleen-monitoring/src/main/java/org/swisspush/gateleen/monitoring/MonitoringHandler.java
@@ -261,7 +261,7 @@ public class MonitoringHandler {
 
     public void updateIncomingRequests(HttpServerRequest request) {
         if (!HttpServerRequestUtil.isRemoteAddressLoopbackAddress(request) && shouldBeTracked(request.uri())) {
-            vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + REQUESTS_INCOMING_NAME).put(METRIC_ACTION, MARK));
+            vertx.eventBus().send(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + REQUESTS_INCOMING_NAME).put(METRIC_ACTION, MARK));
         }
     }
 
@@ -282,7 +282,7 @@ public class MonitoringHandler {
         log.info("About to send {} request per rule monitoring values to metrics", getRequestPerRuleMonitoringMap().size());
         for (Iterator<Map.Entry<String, Long>> it = getRequestPerRuleMonitoringMap().entrySet().iterator(); it.hasNext(); ) {
             Map.Entry<String, Long> entry = it.next();
-            vertx.eventBus().publish(getMonitoringAddress(),
+            vertx.eventBus().send(getMonitoringAddress(),
                     new JsonObject()
                             .put(METRIC_NAME, prefix + REQUEST_PER_RULE_PREFIX + entry.getKey())
                             .put(METRIC_ACTION, SET)
@@ -315,9 +315,9 @@ public class MonitoringHandler {
     public void updateRequestsMeter(String target, String uri) {
         if (shouldBeTracked(uri)) {
             if (isRequestToExternalTarget(target)) {
-                vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + REQUESTS_BACKENDS_NAME).put(METRIC_ACTION, MARK));
+                vertx.eventBus().send(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + REQUESTS_BACKENDS_NAME).put(METRIC_ACTION, MARK));
             } else {
-                vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + REQUESTS_CLIENT_NAME).put(METRIC_ACTION, MARK));
+                vertx.eventBus().send(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + REQUESTS_CLIENT_NAME).put(METRIC_ACTION, MARK));
             }
         }
     }
@@ -334,7 +334,7 @@ public class MonitoringHandler {
         if (shouldBeTracked(targetUri)) {
             if (metricName != null) {
                 time = System.nanoTime();
-                vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + "routing." + metricName).put(METRIC_ACTION, MARK));
+                vertx.eventBus().send(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + "routing." + metricName).put(METRIC_ACTION, MARK));
             }
             updatePendingRequestCount(true);
         }
@@ -352,7 +352,7 @@ public class MonitoringHandler {
         if (shouldBeTracked(targetUri)) {
             if (metricName != null) {
                 double duration = (System.nanoTime() - startTime) / 1000000d;
-                vertx.eventBus().publish(getMonitoringAddress(),
+                vertx.eventBus().send(getMonitoringAddress(),
                         new JsonObject().put(METRIC_NAME, prefix + "routing." + metricName + ".duration").put(METRIC_ACTION, "set").put("n", duration));
             }
             updatePendingRequestCount(false);
@@ -362,7 +362,7 @@ public class MonitoringHandler {
     private void updatePendingRequestCount(boolean incrementCount) {
         final String action = incrementCount ? "inc" : "dec";
         log.trace("Updating count for pending requests: {} remaining", action);
-        vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + PENDING_REQUESTS_METRIC).put(METRIC_ACTION, action));
+        vertx.eventBus().send(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + PENDING_REQUESTS_METRIC).put(METRIC_ACTION, action));
     }
 
     /**
@@ -372,7 +372,7 @@ public class MonitoringHandler {
         vertx.eventBus().request(getRedisquesAddress(), buildGetQueuesCountOperation(), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
             if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
                 final long count = reply.result().body().getLong(VALUE);
-                vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + ACTIVE_QUEUE_COUNT_METRIC).put(METRIC_ACTION, SET).put("n", count));
+                vertx.eventBus().send(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + ACTIVE_QUEUE_COUNT_METRIC).put(METRIC_ACTION, SET).put("n", count));
             } else {
                 log.error("Error gathering count of active queues");
             }
@@ -389,7 +389,7 @@ public class MonitoringHandler {
         vertx.eventBus().request(getRedisquesAddress(), buildGetQueueItemsCountOperation(queue), (Handler<AsyncResult<Message<JsonObject>>>) reply -> {
             if (reply.succeeded() && OK.equals(reply.result().body().getString(STATUS))) {
                 final long count = reply.result().body().getLong(VALUE);
-                vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + LAST_USED_QUEUE_SIZE_METRIC).put(METRIC_ACTION, "set").put("n", count));
+                vertx.eventBus().send(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + LAST_USED_QUEUE_SIZE_METRIC).put(METRIC_ACTION, "set").put("n", count));
             } else {
                 log.error("Error gathering queue size for queue '{}'", queue);
             }
@@ -459,19 +459,19 @@ public class MonitoringHandler {
     }
 
     public void updateEnqueue() {
-        vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + ENQUEUE_METRIC).put(METRIC_ACTION, MARK));
+        vertx.eventBus().send(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + ENQUEUE_METRIC).put(METRIC_ACTION, MARK));
     }
 
     public void updateDequeue() {
-        vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + DEQUEUE_METRIC).put(METRIC_ACTION, MARK));
+        vertx.eventBus().send(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + DEQUEUE_METRIC).put(METRIC_ACTION, MARK));
     }
 
     public void updateListenerCount(long count){
-        vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + LISTENER_COUNT_METRIC).put(METRIC_ACTION, SET).put("n",count));
+        vertx.eventBus().send(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + LISTENER_COUNT_METRIC).put(METRIC_ACTION, SET).put("n",count));
     }
 
     public void updateRoutesCount(long count){
-        vertx.eventBus().publish(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + ROUTE_COUNT_METRIC).put(METRIC_ACTION, SET).put("n",count));
+        vertx.eventBus().send(getMonitoringAddress(), new JsonObject().put(METRIC_NAME, prefix + ROUTE_COUNT_METRIC).put(METRIC_ACTION, SET).put("n",count));
 
     }
 

--- a/gateleen-monitoring/src/test/java/org/swisspush/gateleen/monitoring/MonitoringHandlerTest.java
+++ b/gateleen-monitoring/src/test/java/org/swisspush/gateleen/monitoring/MonitoringHandlerTest.java
@@ -98,25 +98,6 @@ public class MonitoringHandlerTest {
     }
 
     @Test
-    public void testConsumeMonitoringAddress(TestContext testContext){
-        Async async = testContext.async();
-
-        activateRequestPerRuleMonitoring(true);
-        System.setProperty(MonitoringHandler.REQUEST_PER_RULE_SAMPLING_PROPERTY, "100");
-        MonitoringHandler mh = new MonitoringHandler(vertx, storage, PREFIX);
-
-        PUTRequest request = new PUTRequest();
-        request.addHeader(PROPERTY_NAME, "my_value_123");
-        mh.updateRequestPerRuleMonitoring(request, "a_fancy_rule");
-
-        vertx.eventBus().consumer(Address.monitoringAddress(), (Handler<Message<JsonObject>>) message -> {
-            final JsonObject body = message.body();
-            testContext.assertEquals("gateleen.rpr.my_value_123.a_fancy_rule", body.getString("name"));
-            async.complete();
-        });
-    }
-
-    @Test
     public void testWriteRequestPerRuleMonitoringToStorage(){
 
         activateRequestPerRuleMonitoring(true);

--- a/gateleen-monitoring/src/test/java/org/swisspush/gateleen/monitoring/MonitoringHandlerTest.java
+++ b/gateleen-monitoring/src/test/java/org/swisspush/gateleen/monitoring/MonitoringHandlerTest.java
@@ -23,6 +23,10 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.TWO_SECONDS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 
 
 /**
@@ -95,6 +99,26 @@ public class MonitoringHandlerTest {
 
         testContext.assertEquals(10000L, mh.getRequestPerRuleSampling());
         testContext.assertEquals(120L, mh.getRequestPerRuleExpiry());
+    }
+
+    @Test
+    public void tesExternalReceiver(TestContext testContext){
+        Async async = testContext.async();
+
+        activateRequestPerRuleMonitoring(true);
+        System.setProperty(MonitoringHandler.REQUEST_PER_RULE_SAMPLING_PROPERTY, "100");
+        MonitoringHandler mh = new MonitoringHandler(vertx, storage, PREFIX, "/rule/path");
+
+        PUTRequest request = new PUTRequest();
+        request.addHeader(PROPERTY_NAME, "my_value_123");
+
+        mh.registerReceiver(event -> {
+            final JsonObject body = event.body();
+            testContext.assertEquals("gateleen.rpr.my_value_123.a_fancy_rule", body.getString("name"));
+            async.complete();
+        });
+
+        mh.updateRequestPerRuleMonitoring(request, "a_fancy_rule");
     }
 
     @Test


### PR DESCRIPTION
It looks like the monitoring address currently has only a single consumer, and since the address includes a UUID, using publish will cause the clustered eventbus sent garbage message to all nodes.

I'm not entirely certain if other consumers are registered elsewhere, but from what I can see in Gateleen, there doesn’t appear to be a second consumer.
