### PR TITLE
Avoid is not ESM warnings in Angular projects due to to not knowing the types of vertx3-eventbus

### DIFF
--- a/gateleen-hook-ts/package.json
+++ b/gateleen-hook-ts/package.json
@@ -28,10 +28,8 @@
     "format:check": "prettier --check \"*.json\" \"src/**/*.{ts,html,css,scss,json}\"",
     "format:fix": "prettier --write \"*.json\" \"src/**/*.{ts,html,css,scss,json}\""
   },
-  "dependencies": {
-    "vertx3-eventbus-client": "3.9.4"
-  },
   "devDependencies": {
+    "vertx3-eventbus-client": "3.9.4",
     "@types/node": "26.0.0",
     "@vitest/coverage-v8": "4.1.0",
     "@vitest/ui": "4.1.0",

--- a/gateleen-hook-ts/tsup.config.ts
+++ b/gateleen-hook-ts/tsup.config.ts
@@ -3,8 +3,21 @@ import { defineConfig } from 'tsup';
 export default defineConfig([
   {
     // Library build consumed by bundler-based applications (npm package).
+    //
+    // vertx3-eventbus-client (and its sockjs-client dependency) are inlined
+    // (noExternal) rather than left as external imports. That package is
+    // CommonJS-only with no ESM entry point, which trips up strict ESM
+    // consumers (e.g. Angular's esbuild-based builder reports "is not ESM").
+    // Bundling it here means consuming apps never import it directly from
+    // node_modules, so the warning/error disappears and it no longer needs
+    // to be installed as a runtime dependency by consumers.
     entry: ['src/index.ts'],
     format: ['esm', 'cjs'],
+    noExternal: ['vertx3-eventbus-client', 'sockjs-client'],
+    // Ensure esbuild honors dependencies' package.json "browser" field
+    // remappings (see browser bundle config below for details).
+    platform: 'browser',
+    define: { global: 'globalThis' },
     dts: true,
     clean: true
   },


### PR DESCRIPTION
Bundle the vertx3-eventbus-client instead of having it as a dependency.